### PR TITLE
feat: Support more java time types

### DIFF
--- a/src/converters/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesDeserializerWithFromJsonDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesDeserializerWithFromJsonDataObjectConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesSerializerWithToJsonDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesSerializerWithToJsonDataObjectConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/SnakeFormattedDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/SnakeFormattedDataObjectConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/TestDataObjectBase64BasicConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/TestDataObjectBase64BasicConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/TestDataObjectBase64URLConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/TestDataObjectBase64URLConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/main/java/io/vertx/codegen/DataObjectModel.java
+++ b/src/main/java/io/vertx/codegen/DataObjectModel.java
@@ -8,6 +8,11 @@ import io.vertx.codegen.doc.Text;
 import io.vertx.codegen.doc.Token;
 import io.vertx.codegen.type.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
@@ -555,9 +560,14 @@ public class DataObjectModel implements Model {
         break;
       case API:
       case OTHER:
-        jsonifiable = propType.getName().equals(Instant.class.getName()) ||
-          propType.getName().equals("io.vertx.core.buffer.Buffer") ||
-          (propType.isDataObjectHolder() && propType.getDataObject().isSerializable());
+        jsonifiable = propType.getName().equals(Instant.class.getName())
+          || propType.getName().equals(LocalDate.class.getName())
+          || propType.getName().equals(LocalDateTime.class.getName())
+          || propType.getName().equals(LocalTime.class.getName())
+          || propType.getName().equals(OffsetDateTime.class.getName())
+          || propType.getName().equals(ZonedDateTime.class.getName())
+          || propType.getName().equals("io.vertx.core.buffer.Buffer")
+          || (propType.isDataObjectHolder() && propType.getDataObject().isSerializable());
         break;
       default:
         return;

--- a/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
+++ b/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
@@ -22,6 +22,11 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.annotation.Annotation;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 /**
@@ -66,6 +71,11 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
     writer.print("import io.vertx.core.json.JsonArray;\n");
     writer.print("import io.vertx.core.json.impl.JsonUtil;\n");
     writer.print("import java.time.Instant;\n");
+    writer.print("import java.time.LocalDate;\n");
+    writer.print("import java.time.LocalDateTime;\n");
+    writer.print("import java.time.LocalTime;\n");
+    writer.print("import java.time.OffsetDateTime;\n");
+    writer.print("import java.time.ZonedDateTime;\n");
     writer.print("import java.time.format.DateTimeFormatter;\n");
     writer.print("import java.util.Base64;\n");
     writer.print("\n");
@@ -169,6 +179,16 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
               case OTHER:
                 if (prop.getType().getName().equals(Instant.class.getName())) {
                   genPropToJson("DateTimeFormatter.ISO_INSTANT.format(", ")", prop, writer);
+                } else if (prop.getType().getName().equals(LocalDate.class.getName())) {
+                  genPropToJson("DateTimeFormatter.ISO_LOCAL_DATE.format(", ")", prop, writer);
+                } else if (prop.getType().getName().equals(LocalTime.class.getName())) {
+                  genPropToJson("DateTimeFormatter.ISO_LOCAL_TIME.format(", ")", prop, writer);
+                } else if (prop.getType().getName().equals(LocalDateTime.class.getName())) {
+                  genPropToJson("DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(", ")", prop, writer);
+                } else if (prop.getType().getName().equals(OffsetDateTime.class.getName())) {
+                  genPropToJson("DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(", ")", prop, writer);
+                } else if (prop.getType().getName().equals(ZonedDateTime.class.getName())) {
+                  genPropToJson("DateTimeFormatter.ISO_ZONED_DATE_TIME.format(", ")", prop, writer);
                 }
                 break;
             }
@@ -306,6 +326,16 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
               case OTHER:
                 if (prop.getType().getName().equals(Instant.class.getName())) {
                   genPropFromJson("String", "Instant.from(DateTimeFormatter.ISO_INSTANT.parse((String)", "))", prop, writer);
+                } else if (prop.getType().getName().equals(LocalDate.class.getName())) {
+                  genPropFromJson("String", "LocalDate.from(DateTimeFormatter.ISO_LOCAL_DATE.parse((String)", "))", prop, writer);
+                } else if (prop.getType().getName().equals(LocalTime.class.getName())) {
+                  genPropFromJson("String", "LocalTime.from(DateTimeFormatter.ISO_LOCAL_TIME.parse((String)", "))", prop, writer);
+                } else if (prop.getType().getName().equals(LocalDateTime.class.getName())) {
+                  genPropFromJson("String", "LocalDateTime.from(DateTimeFormatter.ISO_LOCAL_DATE_TIME.parse((String)", "))", prop, writer);
+                } else if (prop.getType().getName().equals(OffsetDateTime.class.getName())) {
+                  genPropFromJson("String", "OffsetDateTime.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse((String)", "))", prop, writer);
+                } else if (prop.getType().getName().equals(ZonedDateTime.class.getName())) {
+                  genPropFromJson("String", "ZonedDateTime.from(DateTimeFormatter.ISO_ZONED_DATE_TIME.parse((String)", "))", prop, writer);
                 }
                 break;
               default:

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithBufferConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithBufferConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListAddersConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListAddersConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListsConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListsConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapAddersConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapAddersConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapsConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapsConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithNestedBufferConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithNestedBufferConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithOnlyJsonObjectConstructorConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithOnlyJsonObjectConstructorConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithRecursionConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithRecursionConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithValuesConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithValuesConverter.java
@@ -4,6 +4,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 

--- a/src/test/java/io/vertx/test/codegen/DataObjectTest.java
+++ b/src/test/java/io/vertx/test/codegen/DataObjectTest.java
@@ -19,6 +19,11 @@ import io.vertx.test.codegen.testdataobject.jsonmapper.MyEnumWithCustomFactory;
 import io.vertx.test.codegen.testdataobject.jsonmapper.MyPojo;
 import io.vertx.test.codegen.testdataobject.jsonmapper.DataObjectWithMappedEnum;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import org.junit.Test;
 
 import java.time.Instant;
@@ -102,7 +107,7 @@ public class DataObjectTest {
       .registerConverter(ApiObjectWithMapper.class, ApiObjectWithMapper.class, "toJson")
       .generateDataObject(PropertySetters.class, ApiObjectWithMapper.class);
     assertNotNull(model);
-    assertEquals(15, model.getPropertyMap().size());
+    assertEquals(20, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("string"), "string", "setString", null, null, TypeReflectionFactory.create(String.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("boxedInteger"), "boxedInteger", "setBoxedInteger", null, null, TypeReflectionFactory.create(Integer.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("primitiveInteger"), "primitiveInteger", "setPrimitiveInteger", null, null, TypeReflectionFactory.create(int.class), true, PropertyKind.VALUE, true);
@@ -118,6 +123,11 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("jsonObject"), "jsonObject", "setJsonObject", null, null, TypeReflectionFactory.create(JsonObject.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("jsonArray"), "jsonArray", "setJsonArray", null, null, TypeReflectionFactory.create(JsonArray.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("enumerated"), "enumerated", "setEnumerated", null, null, TypeReflectionFactory.create(Enumerated.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("localDate"), "localDate", "setLocalDate", null, null, TypeReflectionFactory.create(LocalDate.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("localDateTime"), "localDateTime", "setLocalDateTime", null, null, TypeReflectionFactory.create(LocalDateTime.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("localTime"), "localTime", "setLocalTime", null, null, TypeReflectionFactory.create(LocalTime.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("offsetDateTime"), "offsetDateTime", "setOffsetDateTime", null, null, TypeReflectionFactory.create(OffsetDateTime.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("zonedDateTime"), "zonedDateTime", "setZonedDateTime", null, null, TypeReflectionFactory.create(ZonedDateTime.class), true, PropertyKind.VALUE, true);
   }
 
   @Test
@@ -145,7 +155,7 @@ public class DataObjectTest {
       .registerConverter(ApiObjectWithMapper.class, ApiObjectWithMapper.class, "toJson")
       .generateDataObject(dataObjectClass, ApiObjectWithMapper.class);
     assertNotNull(model);
-    assertEquals(13, model.getPropertyMap().size());
+    assertEquals(18, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("extraClassPath"), "extraClassPath", "setExtraClassPath", null, null, TypeReflectionFactory.create(String.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("strings"), "strings", "setStrings", null, null, TypeReflectionFactory.create(String.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("instants"), "instants", "setInstants", null, null, TypeReflectionFactory.create(Instant.class), true, expectedKind, true);
@@ -159,6 +169,11 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("jsonObjects"), "jsonObjects", "setJsonObjects", null, null, TypeReflectionFactory.create(JsonObject.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("jsonArrays"), "jsonArrays", "setJsonArrays", null, null, TypeReflectionFactory.create(JsonArray.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("enumerateds"), "enumerateds", "setEnumerateds", null, null, TypeReflectionFactory.create(Enumerated.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("localDates"), "localDates", "setLocalDates", null, null, TypeReflectionFactory.create(LocalDate.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("localDateTimes"), "localDateTimes", "setLocalDateTimes", null, null, TypeReflectionFactory.create(LocalDateTime.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("localTimes"), "localTimes", "setLocalTimes", null, null, TypeReflectionFactory.create(LocalTime.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("offsetDateTimes"), "offsetDateTimes", "setOffsetDateTimes", null, null, TypeReflectionFactory.create(OffsetDateTime.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("zonedDateTimes"), "zonedDateTimes", "setZonedDateTimes", null, null, TypeReflectionFactory.create(ZonedDateTime.class), true, expectedKind, true);
   }
 
   @Test
@@ -177,7 +192,7 @@ public class DataObjectTest {
       .registerConverter(ApiObjectWithMapper.class, ApiObjectWithMapper.class, "toJson")
       .generateDataObject(dataObjectClass, ApiObjectWithMapper.class);
     assertNotNull(model);
-    assertEquals(13, model.getPropertyMap().size());
+    assertEquals(18, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("extraClassPath"), "extraClassPath", "setExtraClassPath", null, "getExtraClassPath", TypeReflectionFactory.create(String.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("strings"), "strings", "setStrings", null, "getStrings", TypeReflectionFactory.create(String.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("instants"), "instants", "setInstants", null, "getInstants", TypeReflectionFactory.create(Instant.class), true, expectedKind, true);
@@ -191,6 +206,11 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("jsonObjects"), "jsonObjects", "setJsonObjects", null, "getJsonObjects", TypeReflectionFactory.create(JsonObject.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("jsonArrays"), "jsonArrays", "setJsonArrays", null, "getJsonArrays", TypeReflectionFactory.create(JsonArray.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("enumerateds"), "enumerateds", "setEnumerateds", null, "getEnumerateds", TypeReflectionFactory.create(Enumerated.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("localDates"), "localDates", "setLocalDates", null, "getLocalDates", TypeReflectionFactory.create(LocalDate.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("localDateTimes"), "localDateTimes", "setLocalDateTimes", null, "getLocalDateTimes", TypeReflectionFactory.create(LocalDateTime.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("localTimes"), "localTimes", "setLocalTimes", null, "getLocalTimes", TypeReflectionFactory.create(LocalTime.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("offsetDateTimes"), "offsetDateTimes", "setOffsetDateTimes", null, "getOffsetDateTimes", TypeReflectionFactory.create(OffsetDateTime.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("zonedDateTimes"), "zonedDateTimes", "setZonedDateTimes", null, "getZonedDateTimes", TypeReflectionFactory.create(ZonedDateTime.class), true, expectedKind, true);
   }
 
   @Test
@@ -204,7 +224,7 @@ public class DataObjectTest {
       .registerConverter(ApiObjectWithMapper.class, ApiObjectWithMapper.class, "toJson")
       .generateDataObject(PropertyMapGettersSetters.class, ApiObjectWithMapper.class);
     assertNotNull(model);
-    assertEquals(13, model.getPropertyMap().size());
+    assertEquals(18, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("stringMap"), "stringMap", "setStringMap", null, "getStringMap", TypeReflectionFactory.create(String.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("instantMap"), "instantMap", "setInstantMap", null, "getInstantMap", TypeReflectionFactory.create(Instant.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedIntegerMap"), "boxedIntegerMap", "setBoxedIntegerMap", null, "getBoxedIntegerMap", TypeReflectionFactory.create(Integer.class), true, PropertyKind.MAP, true);
@@ -218,6 +238,11 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("jsonArrayMap"), "jsonArrayMap", "setJsonArrayMap", null, "getJsonArrayMap", TypeReflectionFactory.create(JsonArray.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("enumeratedMap"), "enumeratedMap", "setEnumeratedMap", null, "getEnumeratedMap", TypeReflectionFactory.create(Enumerated.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("objectMap"), "objectMap", "setObjectMap", null, "getObjectMap", TypeReflectionFactory.create(Object.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localDateMap"), "localDateMap", "setLocalDateMap", null, "getLocalDateMap", TypeReflectionFactory.create(LocalDate.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localDateTimeMap"), "localDateTimeMap", "setLocalDateTimeMap", null, "getLocalDateTimeMap", TypeReflectionFactory.create(LocalDateTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localTimeMap"), "localTimeMap", "setLocalTimeMap", null, "getLocalTimeMap", TypeReflectionFactory.create(LocalTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("offsetDateTimeMap"), "offsetDateTimeMap", "setOffsetDateTimeMap", null, "getOffsetDateTimeMap", TypeReflectionFactory.create(OffsetDateTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("zonedDateTimeMap"), "zonedDateTimeMap", "setZonedDateTimeMap", null, "getZonedDateTimeMap", TypeReflectionFactory.create(ZonedDateTime.class), true, PropertyKind.MAP, true);
   }
 
   @Test
@@ -226,7 +251,7 @@ public class DataObjectTest {
       .registerConverter(ApiObjectWithMapper.class, ApiObjectWithMapper.class, "toJson")
       .generateDataObject(PropertyMapAdders.class, ApiObjectWithMapper.class);
     assertNotNull(model);
-    assertEquals(16, model.getPropertyMap().size());
+    assertEquals(21, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("strings"), "strings", null, "addString", null, TypeReflectionFactory.create(String.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("instants"), "instants", null, "addInstant", null, TypeReflectionFactory.create(Instant.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedIntegers"), "boxedIntegers", null, "addBoxedInteger", null, TypeReflectionFactory.create(Integer.class), true, PropertyKind.MAP, true);
@@ -243,6 +268,11 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("jsonArrays"), "jsonArrays", null, "addJsonArray", null, TypeReflectionFactory.create(JsonArray.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("enumerateds"), "enumerateds", null, "addEnumerated", null, TypeReflectionFactory.create(Enumerated.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("objects"), "objects", null, "addObject", null, TypeReflectionFactory.create(Object.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localDates"), "localDates", null, "addLocalDate", null, TypeReflectionFactory.create(LocalDate.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localDateTimes"), "localDateTimes", null, "addLocalDateTime", null, TypeReflectionFactory.create(LocalDateTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localTimes"), "localTimes", null, "addLocalTime", null, TypeReflectionFactory.create(LocalTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("offsetDateTimes"), "offsetDateTimes", null, "addOffsetDateTime", null, TypeReflectionFactory.create(OffsetDateTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("zonedDateTimes"), "zonedDateTimes", null, "addZonedDateTime", null, TypeReflectionFactory.create(ZonedDateTime.class), true, PropertyKind.MAP, true);
   }
 
   @Test
@@ -251,7 +281,7 @@ public class DataObjectTest {
       .registerConverter(ApiObjectWithMapper.class, ApiObjectWithMapper.class, "toJson")
       .generateDataObject(PropertyMapSetters.class, ApiObjectWithMapper.class);
     assertNotNull(model);
-    assertEquals(13, model.getPropertyMap().size());
+    assertEquals(18, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("stringMap"), "stringMap", "setStringMap", null, null, TypeReflectionFactory.create(String.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("instantMap"), "instantMap", "setInstantMap", null, null, TypeReflectionFactory.create(Instant.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedIntegerMap"), "boxedIntegerMap", "setBoxedIntegerMap", null, null, TypeReflectionFactory.create(Integer.class), true, PropertyKind.MAP, true);
@@ -265,6 +295,11 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("jsonArrayMap"), "jsonArrayMap", "setJsonArrayMap", null, null, TypeReflectionFactory.create(JsonArray.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("enumeratedMap"), "enumeratedMap", "setEnumeratedMap", null, null, TypeReflectionFactory.create(Enumerated.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("objectMap"), "objectMap", "setObjectMap", null, null, TypeReflectionFactory.create(Object.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localDateMap"), "localDateMap", "setLocalDateMap", null, null, TypeReflectionFactory.create(LocalDate.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localDateTimeMap"), "localDateTimeMap", "setLocalDateTimeMap", null, null, TypeReflectionFactory.create(LocalDateTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localTimeMap"), "localTimeMap", "setLocalTimeMap", null, null, TypeReflectionFactory.create(LocalTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("offsetDateTimeMap"), "offsetDateTimeMap", "setOffsetDateTimeMap", null, null, TypeReflectionFactory.create(OffsetDateTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("zonedDateTimeMap"), "zonedDateTimeMap", "setZonedDateTimeMap", null, null, TypeReflectionFactory.create(ZonedDateTime.class), true, PropertyKind.MAP, true);
   }
 
   @Test
@@ -273,7 +308,7 @@ public class DataObjectTest {
       .registerConverter(ApiObjectWithMapper.class, ApiObjectWithMapper.class, "toJson")
       .generateDataObject(PropertyMapGettersAdders.class, ApiObjectWithMapper.class);
     assertNotNull(model);
-    assertEquals(13, model.getPropertyMap().size());
+    assertEquals(18, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("strings"), "strings", null, "addString", "getStrings", TypeReflectionFactory.create(String.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("instants"), "instants", null, "addInstant", "getInstants", TypeReflectionFactory.create(Instant.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedIntegers"), "boxedIntegers", null, "addBoxedInteger", "getBoxedIntegers", TypeReflectionFactory.create(Integer.class), true, PropertyKind.MAP, true);
@@ -287,6 +322,11 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("jsonArrays"), "jsonArrays", null, "addJsonArray", "getJsonArrays", TypeReflectionFactory.create(JsonArray.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("enumerateds"), "enumerateds", null, "addEnumerated", "getEnumerateds", TypeReflectionFactory.create(Enumerated.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("objects"), "objects", null, "addObject", "getObjects", TypeReflectionFactory.create(Object.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localDates"), "localDates", null, "addLocalDate", "getLocalDates", TypeReflectionFactory.create(LocalDate.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localDateTimes"), "localDateTimes", null, "addLocalDateTime", "getLocalDateTimes", TypeReflectionFactory.create(LocalDateTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("localTimes"), "localTimes", null, "addLocalTime", "getLocalTimes", TypeReflectionFactory.create(LocalTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("offsetDateTimes"), "offsetDateTimes", null, "addOffsetDateTime", "getOffsetDateTimes", TypeReflectionFactory.create(OffsetDateTime.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("zonedDateTimes"), "zonedDateTimes", null, "addZonedDateTime", "getZonedDateTimes", TypeReflectionFactory.create(ZonedDateTime.class), true, PropertyKind.MAP, true);
   }
 
   @Test
@@ -295,7 +335,7 @@ public class DataObjectTest {
       .registerConverter(ApiObjectWithMapper.class, ApiObjectWithMapper.class, "toJson")
       .generateDataObject(PropertyGetters.class, ApiObjectWithMapper.class);
     assertNotNull(model);
-    assertEquals(15, model.getPropertyMap().size());
+    assertEquals(20, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("string"), "string", null, null, "getString", TypeReflectionFactory.create(String.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("boxedInteger"), "boxedInteger", null, null, "getBoxedInteger", TypeReflectionFactory.create(Integer.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("primitiveInteger"), "primitiveInteger", null, null, "getPrimitiveInteger", TypeReflectionFactory.create(int.class), true, PropertyKind.VALUE, true);
@@ -311,6 +351,11 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("jsonObject"), "jsonObject", null, null, "getJsonObject", TypeReflectionFactory.create(JsonObject.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("jsonArray"), "jsonArray", null, null, "getJsonArray", TypeReflectionFactory.create(JsonArray.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("enumerated"), "enumerated", null, null, "getEnumerated", TypeReflectionFactory.create(Enumerated.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("localDate"), "localDate", null, null, "getLocalDate", TypeReflectionFactory.create(LocalDate.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("localDateTime"), "localDateTime", null, null, "getLocalDateTime", TypeReflectionFactory.create(LocalDateTime.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("localTime"), "localTime", null, null, "getLocalTime", TypeReflectionFactory.create(LocalTime.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("offsetDateTime"), "offsetDateTime", null, null, "getOffsetDateTime", TypeReflectionFactory.create(OffsetDateTime.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("zonedDateTime"), "zonedDateTime", null, null, "getZonedDateTime", TypeReflectionFactory.create(ZonedDateTime.class), true, PropertyKind.VALUE, true);
   }
 
   @Test
@@ -320,7 +365,7 @@ public class DataObjectTest {
       .registerConverter(ApiObjectWithMapper.class, ApiObjectWithMapper.class, "toJson")
       .generateDataObject(PropertyGettersSetters.class, ApiObjectWithMapper.class);
     assertNotNull(model);
-    assertEquals(15, model.getPropertyMap().size());
+    assertEquals(20, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("string"), "string", "setString", null, "getString", TypeReflectionFactory.create(String.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("instant"), "instant", "setInstant", null, "getInstant", TypeReflectionFactory.create(Instant.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("boxedInteger"), "boxedInteger", "setBoxedInteger", null, "getBoxedInteger", TypeReflectionFactory.create(Integer.class), true, PropertyKind.VALUE, true);
@@ -336,6 +381,11 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("jsonObject"), "jsonObject", "setJsonObject", null, "getJsonObject", TypeReflectionFactory.create(JsonObject.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("jsonArray"), "jsonArray", "setJsonArray", null, "getJsonArray", TypeReflectionFactory.create(JsonArray.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("enumerated"), "enumerated", "setEnumerated", null, "getEnumerated", TypeReflectionFactory.create(Enumerated.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("localDate"), "localDate", "setLocalDate", null, "getLocalDate", TypeReflectionFactory.create(LocalDate.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("localDateTime"), "localDateTime", "setLocalDateTime", null, "getLocalDateTime", TypeReflectionFactory.create(LocalDateTime.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("localTime"), "localTime", "setLocalTime", null, "getLocalTime", TypeReflectionFactory.create(LocalTime.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("offsetDateTime"), "offsetDateTime", "setOffsetDateTime", null, "getOffsetDateTime", TypeReflectionFactory.create(OffsetDateTime.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("zonedDateTime"), "zonedDateTime", "setZonedDateTime", null, "getZonedDateTime", TypeReflectionFactory.create(ZonedDateTime.class), true, PropertyKind.VALUE, true);
   }
 
   @Test
@@ -352,7 +402,7 @@ public class DataObjectTest {
       .registerConverter(ApiObjectWithMapper.class, ApiObjectWithMapper.class, "toJson")
       .generateDataObject(PropertyListAdders.class, ApiObjectWithMapper.class);
     assertNotNull(model);
-    assertEquals(15, model.getPropertyMap().size());
+    assertEquals(20, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("strings"), "strings", null, "addString", null, TypeReflectionFactory.create(String.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("instants"), "instants", null, "addInstant", null, TypeReflectionFactory.create(Instant.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("boxedIntegers"), "boxedIntegers", null, "addBoxedInteger", null, TypeReflectionFactory.create(Integer.class), true, PropertyKind.LIST, true);
@@ -368,6 +418,11 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("jsonObjects"), "jsonObjects", null, "addJsonObject", null, TypeReflectionFactory.create(JsonObject.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("jsonArrays"), "jsonArrays", null, "addJsonArray", null, TypeReflectionFactory.create(JsonArray.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("enumerateds"), "enumerateds", null, "addEnumerated", null, TypeReflectionFactory.create(Enumerated.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("localDates"), "localDates", null, "addLocalDate", null, TypeReflectionFactory.create(LocalDate.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("localDateTimes"), "localDateTimes", null, "addLocalDateTime", null, TypeReflectionFactory.create(LocalDateTime.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("localTimes"), "localTimes", null, "addLocalTime", null, TypeReflectionFactory.create(LocalTime.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("offsetDateTimes"), "offsetDateTimes", null, "addOffsetDateTime", null, TypeReflectionFactory.create(OffsetDateTime.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("zonedDateTimes"), "zonedDateTimes", null, "addZonedDateTime", null, TypeReflectionFactory.create(ZonedDateTime.class), true, PropertyKind.LIST, true);
   }
 
   @Test
@@ -377,7 +432,7 @@ public class DataObjectTest {
       .registerConverter(ApiObjectWithMapper.class, ApiObjectWithMapper.class, "toJson")
       .generateDataObject(PropertyListGettersAdders.class, ApiObjectWithMapper.class);
     assertNotNull(model);
-    assertEquals(12, model.getPropertyMap().size());
+    assertEquals(17, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("strings"), "strings", null, "addString", "getStrings", TypeReflectionFactory.create(String.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("instants"), "instants", null, "addInstant", "getInstants", TypeReflectionFactory.create(Instant.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("boxedIntegers"), "boxedIntegers", null, "addBoxedInteger", "getBoxedIntegers", TypeReflectionFactory.create(Integer.class), true, PropertyKind.LIST, true);
@@ -390,6 +445,11 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("jsonObjects"), "jsonObjects", null, "addJsonObject", "getJsonObjects", TypeReflectionFactory.create(JsonObject.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("jsonArrays"), "jsonArrays", null, "addJsonArray", "getJsonArrays", TypeReflectionFactory.create(JsonArray.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("enumerateds"), "enumerateds", null, "addEnumerated", "getEnumerateds", TypeReflectionFactory.create(Enumerated.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("localDates"), "localDates", null, "addLocalDate", "getLocalDates", TypeReflectionFactory.create(LocalDate.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("localDateTimes"), "localDateTimes", null, "addLocalDateTime", "getLocalDateTimes", TypeReflectionFactory.create(LocalDateTime.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("localTimes"), "localTimes", null, "addLocalTime", "getLocalTimes", TypeReflectionFactory.create(LocalTime.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("offsetDateTimes"), "offsetDateTimes", null, "addOffsetDateTime", "getOffsetDateTimes", TypeReflectionFactory.create(OffsetDateTime.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("zonedDateTimes"), "zonedDateTimes", null, "addZonedDateTime", "getZonedDateTimes", TypeReflectionFactory.create(ZonedDateTime.class), true, PropertyKind.LIST, true);
   }
 
   @Test

--- a/src/test/java/io/vertx/test/codegen/generator/CodeGeneratorTest.java
+++ b/src/test/java/io/vertx/test/codegen/generator/CodeGeneratorTest.java
@@ -13,6 +13,11 @@ import io.vertx.test.codegen.testdataobject.PropertyGettersSetters;
 import io.vertx.test.codegen.testenum.ValidEnum;
 import io.vertx.test.codegen.testmodule.modulescoped.ModuleScopedApi;
 import io.vertx.test.codegen.testmodule.modulescoped.sub.ModuleScopedSubApi;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -95,9 +100,25 @@ public class CodeGeneratorTest {
     assertEquals("true", props.remove("publicConverter"));
     assertEquals("false", props.remove("concrete"));
     assertEquals("false", props.remove("isClass"));
-    assertEquals("[" + JsonArray.class.getName() + ", " + JsonObject.class.getName() + ", " + Boolean.class.getName() + ", "
-        + Integer.class.getName() + ", " + Long.class.getName() + ", " + String.class.getName() + ", " + Instant.class.getName()
-        + "]", props.remove("importedTypes"));
+    assertEquals("false", props.remove("deprecated"));
+    assertEquals("null", props.remove("deprecatedDesc"));
+    assertEquals("false", props.remove("hasStringConstructor"));
+
+    List<String> classNames = Arrays.asList(
+      JsonArray.class.getName(),
+      JsonObject.class.getName(),
+      Boolean.class.getName(),
+      Integer.class.getName(),
+      Long.class.getName(),
+      String.class.getName(),
+      Instant.class.getName(),
+      LocalDate.class.getName(),
+      LocalDateTime.class.getName(),
+      LocalTime.class.getName(),
+      OffsetDateTime.class.getName(),
+      ZonedDateTime.class.getName()
+    );
+    assertEquals("[" + String.join(", ", classNames) + "]", props.remove("importedTypes"));
     assertEquals("[]", props.remove("superTypes"));
     assertEquals("[]", props.remove("abstractSuperTypes"));
     assertEquals("null", props.remove("superType"));
@@ -115,12 +136,20 @@ public class CodeGeneratorTest {
     assertEquals("long", props.remove("property.primitiveLong"));
     assertEquals("java.lang.String", props.remove("property.string"));
     assertEquals("java.time.Instant", props.remove("property.instant"));
+    assertEquals("java.time.LocalDate", props.remove("property.localDate"));
+    assertEquals("java.time.LocalDateTime", props.remove("property.localDateTime"));
+    assertEquals("java.time.LocalTime", props.remove("property.localTime"));
+    assertEquals("java.time.OffsetDateTime", props.remove("property.offsetDateTime"));
+    assertEquals("java.time.ZonedDateTime", props.remove("property.zonedDateTime"));
     assertEquals("io.vertx.test.codegen.testdataobject.ToJsonDataObject", props.remove("property.toJsonDataObject"));
     assertEquals("false", props.remove("hasEmptyConstructor"));
     assertEquals("false", props.remove("hasJsonConstructor"));
     assertEquals("false", props.remove("hasToJsonMethod"));
     assertEquals("false", props.remove("serializable"));
     assertEquals("false", props.remove("deserializable"));
+
+    int numberOfIgnoredProps = 4;
+    assertEquals(numberOfIgnoredProps, props.size());
   }
 
   @Test

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyGetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyGetters.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -32,6 +37,12 @@ public class PropertyGetters {
   public Long getBoxedLong() { throw new UnsupportedOperationException(); }
   public long getPrimitiveLong() { throw new UnsupportedOperationException(); }
   public Instant getInstant() { throw new UnsupportedOperationException(); }
+
+  public LocalDate getLocalDate() { throw new UnsupportedOperationException(); }
+  public LocalDateTime getLocalDateTime() { throw new UnsupportedOperationException(); }
+  public LocalTime getLocalTime() { throw new UnsupportedOperationException(); }
+  public OffsetDateTime getOffsetDateTime() { throw new UnsupportedOperationException(); }
+  public ZonedDateTime getZonedDateTime() { throw new UnsupportedOperationException(); }
 
   public ApiObject getApiObject() { throw new UnsupportedOperationException(); }
   public ApiObjectWithMapper getApiObjectWithMapper() { throw new UnsupportedOperationException(); }

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyGettersSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyGettersSetters.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Map;
 
 /**
@@ -25,6 +30,16 @@ public interface PropertyGettersSetters {
   String getString();
   void setInstant(Instant i);
   Instant getInstant();
+  void setLocalDate(LocalDate l);
+  LocalDate getLocalDate();
+  void setLocalDateTime(LocalDateTime l);
+  LocalDateTime getLocalDateTime();
+  void setLocalTime(LocalTime l);
+  LocalTime getLocalTime();
+  void setOffsetDateTime(OffsetDateTime o);
+  OffsetDateTime getOffsetDateTime();
+  void setZonedDateTime(ZonedDateTime z);
+  ZonedDateTime getZonedDateTime();
   void setBoxedInteger(Integer i);
   Integer getBoxedInteger();
   void setPrimitiveInteger(int i);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListAdders.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListAdders.java
@@ -5,6 +5,12 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -22,6 +28,11 @@ public interface PropertyListAdders {
 
   PropertyListAdders addString(String s);
   PropertyListAdders addInstant(Instant i);
+  PropertySetSetters addLocalDate(LocalDate localDate);
+  PropertySetSetters addLocalDateTime(LocalDateTime localDateTime);
+  PropertySetSetters addLocalTime(LocalTime localTime);
+  PropertySetSetters addOffsetDateTime(OffsetDateTime offsetDateTime);
+  PropertySetSetters addZonedDateTime(ZonedDateTime zonedDateTime);
   PropertyListAdders addBoxedInteger(Integer i);
   PropertyListAdders addPrimitiveInteger(int i);
   PropertyListAdders addBoxedBoolean(Boolean b);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListGettersAdders.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListGettersAdders.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -25,6 +30,16 @@ public interface PropertyListGettersAdders {
   PropertyListGettersAdders addString(String s);
   List<Instant> getInstants();
   PropertyListGettersAdders addInstant(Instant i);
+  List<LocalDate> getLocalDates();
+  PropertyListGettersAdders addLocalDate(LocalDate l);
+  List<LocalDateTime> getLocalDateTimes();
+  PropertyListGettersAdders addLocalDateTime(LocalDateTime l);
+  List<LocalTime> getLocalTimes();
+  PropertyListGettersAdders addLocalTime(LocalTime l);
+  List<OffsetDateTime> getOffsetDateTimes();
+  PropertyListGettersAdders addOffsetDateTime(OffsetDateTime o);
+  List<ZonedDateTime> getZonedDateTimes();
+  PropertyListGettersAdders addZonedDateTime(ZonedDateTime z);
   List<Integer> getBoxedIntegers();
   PropertyListGettersAdders addBoxedInteger(Integer i);
   List<Boolean> getBoxedBooleans();

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListGettersSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListGettersSetters.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -30,6 +35,16 @@ public interface PropertyListGettersSetters {
   PropertyListGettersSetters setStrings(List<String> s);
   List<Instant> getInstants();
   PropertyListGettersSetters setInstants(List<Instant> s);
+  List<LocalDate> getLocalDates();
+  PropertyListGettersSetters setLocalDates(List<LocalDate> l);
+  List<LocalDateTime> getLocalDateTimes();
+  PropertyListGettersSetters setLocalDateTimes(List<LocalDateTime> l);
+  List<LocalTime> getLocalTimes();
+  PropertyListGettersSetters setLocalTimes(List<LocalTime> l);
+  List<OffsetDateTime> getOffsetDateTimes();
+  PropertyListGettersSetters setOffsetDateTimes(List<OffsetDateTime> o);
+  List<ZonedDateTime> getZonedDateTimes();
+  PropertyListGettersSetters setZonedDateTimes(List<ZonedDateTime> z);
   List<Integer> getBoxedIntegers();
   PropertyListGettersSetters setBoxedIntegers(List<Integer> i);
   List<Boolean> getBoxedBooleans();

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListSetters.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -27,6 +32,11 @@ public interface PropertyListSetters {
   // Regular case
   PropertyListSetters setStrings(List<String> s);
   PropertyListSetters setInstants(List<Instant> s);
+  PropertyListSetters setLocalDates(List<LocalDate> l);
+  PropertyListSetters setLocalDateTimes(List<LocalDateTime> l);
+  PropertyListSetters setLocalTimes(List<LocalTime> l);
+  PropertyListSetters setOffsetDateTimes(List<OffsetDateTime> o);
+  PropertyListSetters setZonedDateTimes(List<ZonedDateTime> z);
   PropertyListSetters setBoxedIntegers(List<Integer> i);
   PropertyListSetters setBoxedBooleans(List<Boolean> b);
   PropertyListSetters setBoxedLongs(List<Long> b);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapAdders.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapAdders.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Map;
 
 /**
@@ -24,6 +29,11 @@ public interface PropertyMapAdders {
   // Regular case
   PropertyMapAdders addString(String key, String s);
   PropertyMapAdders addInstant(String key, Instant i);
+  PropertyMapAdders addLocalDate(String key, LocalDate l);
+  PropertyMapAdders addLocalDateTime(String key, LocalDateTime i);
+  PropertyMapAdders addLocalTime(String key, LocalTime i);
+  PropertyMapAdders addOffsetDateTime(String key, OffsetDateTime i);
+  PropertyMapAdders addZonedDateTime(String key, ZonedDateTime i);
   PropertyMapAdders addBoxedInteger(String key, Integer i);
   PropertyMapAdders addPrimitiveInteger(String key, int i);
   PropertyMapAdders addBoxedBoolean(String key, Boolean b);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapGettersAdders.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapGettersAdders.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Map;
 
 /**
@@ -26,6 +31,16 @@ public interface PropertyMapGettersAdders {
   PropertyMapGettersAdders addString(String key, String s);
   Map<String, Instant> getInstants();
   PropertyMapGettersAdders addInstant(String key, Instant i);
+  Map<String, LocalDate> getLocalDates();
+  PropertyMapGettersAdders addLocalDate(String key, LocalDate l);
+  Map<String, LocalDateTime> getLocalDateTimes();
+  PropertyMapGettersAdders addLocalDateTime(String key, LocalDateTime l);
+  Map<String, LocalTime> getLocalTimes();
+  PropertyMapGettersAdders addLocalTime(String key, LocalTime l);
+  Map<String, OffsetDateTime> getOffsetDateTimes();
+  PropertyMapGettersAdders addOffsetDateTime(String key, OffsetDateTime o);
+  Map<String, ZonedDateTime> getZonedDateTimes();
+  PropertyMapGettersAdders addZonedDateTime(String key, ZonedDateTime z);
   Map<String, Integer> getBoxedIntegers();
   PropertyMapGettersAdders addBoxedInteger(String key, Integer i);
   Map<String, Boolean> getBoxedBooleans();

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapGettersSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapGettersSetters.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -27,6 +32,16 @@ public interface PropertyMapGettersSetters {
   PropertyMapGettersSetters setStringMap(Map<String, String> s);
   Map<String, Instant> getInstantMap();
   PropertyMapGettersSetters setInstantMap(Map<String, Instant> i);
+  Map<String, LocalDate> getLocalDateMap();
+  PropertyMapGettersSetters setLocalDateMap(Map<String, LocalDate> l);
+  Map<String, LocalDateTime> getLocalDateTimeMap();
+  PropertyMapGettersSetters setLocalDateTimeMap(Map<String, LocalDateTime> l);
+  Map<String, LocalTime> getLocalTimeMap();
+  PropertyMapGettersSetters setLocalTimeMap(Map<String, LocalTime> l);
+  Map<String, OffsetDateTime> getOffsetDateTimeMap();
+  PropertyMapGettersSetters setOffsetDateTimeMap(Map<String, OffsetDateTime> o);
+  Map<String, ZonedDateTime> getZonedDateTimeMap();
+  PropertyMapGettersSetters setZonedDateTimeMap(Map<String, ZonedDateTime> z);
   Map<String, Integer> getBoxedIntegerMap();
   PropertyMapGettersSetters setBoxedIntegerMap(Map<String, Integer> i);
   Map<String, Boolean> getBoxedBooleanMap();

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapSetters.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -25,6 +30,11 @@ public interface PropertyMapSetters {
   // Regular case
   PropertyMapSetters setStringMap(Map<String, String> s);
   PropertyMapSetters setInstantMap(Map<String, Instant> i);
+  PropertyMapSetters setLocalDateMap(Map<String, LocalDate> l);
+  PropertyMapSetters setLocalDateTimeMap(Map<String, LocalDateTime> l);
+  PropertyMapSetters setLocalTimeMap(Map<String, LocalTime> l);
+  PropertyMapSetters setOffsetDateTimeMap(Map<String, OffsetDateTime> o);
+  PropertyMapSetters setZonedDateTimeMap(Map<String, ZonedDateTime> z);
   PropertyMapSetters setBoxedIntegerMap(Map<String, Integer> i);
   PropertyMapSetters setBoxedBooleanMap(Map<String, Boolean> b);
   PropertyMapSetters setBoxedLongMap(Map<String, Long> b);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetGettersSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetGettersSetters.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Set;
 
 /**
@@ -30,6 +35,16 @@ public interface PropertySetGettersSetters {
   PropertySetGettersSetters setStrings(Set<String> s);
   Set<Instant> getInstants();
   PropertySetGettersSetters setInstants(Set<Instant> i);
+  Set<LocalDate> getLocalDates();
+  PropertySetGettersSetters setLocalDates(Set<LocalDate> l);
+  Set<LocalDateTime> getLocalDateTimes();
+  PropertySetGettersSetters setLocalDateTimes(Set<LocalDateTime> l);
+  Set<LocalTime> getLocalTimes();
+  PropertySetGettersSetters setLocalTimes(Set<LocalTime> l);
+  Set<OffsetDateTime> getOffsetDateTimes();
+  PropertySetGettersSetters setOffsetDateTimes(Set<OffsetDateTime> o);
+  Set<ZonedDateTime> getZonedDateTimes();
+  PropertySetGettersSetters setZonedDateTimes(Set<ZonedDateTime> z);
   Set<Integer> getBoxedIntegers();
   PropertySetGettersSetters setBoxedIntegers(Set<Integer> i);
   Set<Boolean> getBoxedBooleans();

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetSetters.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Set;
 
 /**
@@ -27,6 +32,11 @@ public interface PropertySetSetters {
   // Regular case
   PropertySetSetters setStrings(Set<String> s);
   PropertySetSetters setInstants(Set<Instant> i);
+  PropertySetSetters setLocalDates(Set<LocalDate> localDates);
+  PropertySetSetters setLocalDateTimes(Set<LocalDateTime> localDateTimes);
+  PropertySetSetters setLocalTimes(Set<LocalTime> localTimes);
+  PropertySetSetters setOffsetDateTimes(Set<OffsetDateTime> offsetDateTimes);
+  PropertySetSetters setZonedDateTimes(Set<ZonedDateTime> zonedDateTimes);
   PropertySetSetters setBoxedIntegers(Set<Integer> i);
   PropertySetSetters setBoxedBooleans(Set<Boolean> b);
   PropertySetSetters setBoxedLongs(Set<Long> b);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetters.java
@@ -5,6 +5,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -32,6 +37,11 @@ public class PropertySetters {
   public PropertySetters setBoxedLong(Long b) { throw new UnsupportedOperationException(); }
   public PropertySetters setPrimitiveLong(long b) { throw new UnsupportedOperationException(); }
   public PropertySetters setInstant(Instant i) { throw new UnsupportedOperationException(); }
+  public PropertySetters setLocalDate(LocalDate l) { throw new UnsupportedOperationException(); }
+  public PropertySetters setLocalDateTime(LocalDateTime l) { throw new UnsupportedOperationException(); }
+  public PropertySetters setLocalTime(LocalTime l) { throw new UnsupportedOperationException(); }
+  public PropertySetters setOffsetDateTime(OffsetDateTime o) { throw new UnsupportedOperationException(); }
+  public PropertySetters setZonedDateTime(ZonedDateTime z) { throw new UnsupportedOperationException(); }
 
   public PropertySetters setApiObject(ApiObject s) { throw new UnsupportedOperationException(); }
   public PropertySetters setApiObjectWithMapper(ApiObjectWithMapper s) { throw new UnsupportedOperationException(); }


### PR DESCRIPTION
Codegen is only able to generate converters that handles Java Instants. This PR enables the generation of converters that additionally supports LocalTime, LocalDate, LocalDateTime, OffsetDateTime and ZonedDateTime properties.