### PR TITLE
fix: add windows support to default kapt builds

### DIFF
--- a/src/main/java/io/vertx/codegen/CodeGenProcessor.java
+++ b/src/main/java/io/vertx/codegen/CodeGenProcessor.java
@@ -223,6 +223,8 @@ public class CodeGenProcessor extends AbstractProcessor {
     if (exception != null) {
       String kaptGeneratedLocation = processingEnv.getOptions().get("kapt.kotlin.generated");
       String defaultKaptGeneratedLocation = "/build/generated/source/kaptKotlin/main";
+      defaultKaptGeneratedLocation = defaultKaptGeneratedLocation.replace('/', File.separatorChar);
+
       if (kaptGeneratedLocation != null && kaptGeneratedLocation.endsWith(defaultKaptGeneratedLocation)) {
         File projectDir = new File(kaptGeneratedLocation.substring(0, kaptGeneratedLocation.length() - defaultKaptGeneratedLocation.length()));
         Path source = projectDir.toPath().resolve("src/main/resources").resolve(JSON_MAPPERS_PROPERTIES_PATH);


### PR DESCRIPTION
Motivation:

Sorry, forgot about Windows paths. Thankfully it's not a regression as Kapt builds simply continued not to work on Windows. This fixes that issue.