### PR TITLE
Add option to fail the build when a callback method is not deprecated

### DIFF
--- a/src/main/java/io/vertx/codegen/ClassModel.java
+++ b/src/main/java/io/vertx/codegen/ClassModel.java
@@ -821,6 +821,11 @@ public class ClassModel implements Model {
       useFutures,
       methodOverride);
 
+    //
+    if (methodInfo.getKind() == MethodKind.CALLBACK && !methodInfo.isDeprecated() && getModule().checkCallbackDeprecation) {
+      throw new GenException(modelMethod, "Callback method must be deprecated");
+    }
+
     // Check we don't hide another method, we don't check overrides but we are more
     // interested by situations like diamond inheritance of the same method, in this case
     // we see two methods with the same signature that don't override each other

--- a/src/main/java/io/vertx/codegen/ModuleInfo.java
+++ b/src/main/java/io/vertx/codegen/ModuleInfo.java
@@ -33,12 +33,14 @@ public class ModuleInfo {
 
   // Only used internally
   final boolean useFutures;
+  final boolean checkCallbackDeprecation;
 
-  public ModuleInfo(String packageName, String name, String groupPackage, boolean useFutures) {
+  public ModuleInfo(String packageName, String name, String groupPackage, boolean useFutures, boolean checkCallbackDeprecation) {
     this.packageName = packageName;
     this.name = name;
     this.groupPackage = groupPackage;
     this.useFutures = useFutures;
+    this.checkCallbackDeprecation = checkCallbackDeprecation;
   }
 
   private static final BiFunction<Elements, String, Set<PackageElement>> getPackageElementJava8 = (elts, fqn) -> {
@@ -76,7 +78,7 @@ public class ModuleInfo {
     PackageElement result = resolveFirstModuleGenAnnotatedPackageElement(elementUtils, pkgElt);
     if (result != null) {
       ModuleGen annotation = result.getAnnotation(ModuleGen.class);
-      return new ModuleInfo(result.getQualifiedName().toString(), annotation.name(), annotation.groupPackage(), annotation.useFutures());
+      return new ModuleInfo(result.getQualifiedName().toString(), annotation.name(), annotation.groupPackage(), annotation.useFutures(), annotation.checkCallbackDeprecation());
     } else return null;
   }
 

--- a/src/main/java/io/vertx/codegen/ModuleModel.java
+++ b/src/main/java/io/vertx/codegen/ModuleModel.java
@@ -56,7 +56,7 @@ public class ModuleModel implements Model {
     } catch (Exception e) {
       throw new GenException(element, "Invalid group package name " + groupPackage);
     }
-    ModuleInfo info = new ModuleInfo(modulePackage, moduleName, groupPackage, annotation.useFutures());
+    ModuleInfo info = new ModuleInfo(modulePackage, moduleName, groupPackage, annotation.useFutures(), annotation.checkCallbackDeprecation());
     AnnotationValueInfoFactory annotationFactory = new AnnotationValueInfoFactory(new TypeMirrorFactory(elementUtils, typeUtils));
     List<AnnotationValueInfo> annotationValueInfos = element
       .getAnnotationMirrors()

--- a/src/main/java/io/vertx/codegen/annotations/ModuleGen.java
+++ b/src/main/java/io/vertx/codegen/annotations/ModuleGen.java
@@ -60,4 +60,6 @@ public @interface ModuleGen {
    */
   boolean useFutures() default false;
 
+  boolean checkCallbackDeprecation() default false;
+
 }

--- a/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
+++ b/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
@@ -22,7 +22,7 @@ import java.util.Map;
  */
 public class TypeMirrorFactory {
 
-  private static final ModuleInfo VERTX_CORE_MOD = new ModuleInfo("io.vertx.core", "vertx", "io.vertx", false);
+  private static final ModuleInfo VERTX_CORE_MOD = new ModuleInfo("io.vertx.core", "vertx", "io.vertx", false, false);
   private static final ClassTypeInfo JSON_OBJECT = new ClassTypeInfo(ClassKind.JSON_OBJECT, "io.vertx.core.json.JsonObject", VERTX_CORE_MOD, false, Collections.emptyList(), null);
   private static final ClassTypeInfo STRING = new ClassTypeInfo(ClassKind.STRING, "java.lang.String", null, false, Collections.emptyList(), null);
 

--- a/src/main/java/io/vertx/codegen/type/TypeReflectionFactory.java
+++ b/src/main/java/io/vertx/codegen/type/TypeReflectionFactory.java
@@ -41,7 +41,7 @@ public class TypeReflectionFactory {
           while (pkg != null) {
             ModuleGen annotation = pkg.getAnnotation(ModuleGen.class);
             if (annotation != null) {
-              module = new ModuleInfo(pkg.getName(), annotation.name(), annotation.groupPackage(), annotation.useFutures());
+              module = new ModuleInfo(pkg.getName(), annotation.name(), annotation.groupPackage(), annotation.useFutures(), annotation.checkCallbackDeprecation());
               break;
             } else {
               int pos = pkg.getName().lastIndexOf('.');


### PR DESCRIPTION
This is a temporary option, that will get removed later after callback cleanup.