### PR TITLE
Codegen formatter pluggabilty

### DIFF
--- a/vertx-codegen-json/src/main/java/io/vertx/codegen/json/generator/DataObjectJsonGen.java
+++ b/vertx-codegen-json/src/main/java/io/vertx/codegen/json/generator/DataObjectJsonGen.java
@@ -377,19 +377,6 @@ public class DataObjectJsonGen extends Generator<DataObjectModel> {
       .stream().filter(ann -> ann.getName().equals(DataObject.class.getName()))
       .findFirst().get();
     ClassTypeInfo cti = (ClassTypeInfo) abc.getMember("jsonPropertyNameFormatter");
-    switch (cti.getName()) {
-      case "io.vertx.codegen.format.CamelCase":
-        return CamelCase.INSTANCE;
-      case "io.vertx.codegen.format.SnakeCase":
-        return SnakeCase.INSTANCE;
-      case "io.vertx.codegen.format.LowerCamelCase":
-        return LowerCamelCase.INSTANCE;
-      case "io.vertx.codegen.format.KebabCase":
-        return KebabCase.INSTANCE;
-      case "io.vertx.codegen.format.QualifiedCase":
-        return QualifiedCase.INSTANCE;
-      default:
-        throw new UnsupportedOperationException("Todo");
-    }
+    return Case.loadCase(cti.getName());
   }
 }

--- a/vertx-codegen-json/src/test/java/io/vertx/test/codegen/converter/DataObjectTest.java
+++ b/vertx-codegen-json/src/test/java/io/vertx/test/codegen/converter/DataObjectTest.java
@@ -850,6 +850,22 @@ public class DataObjectTest {
   }
 
   @Test
+  public void testExternallyFormatted() {
+    ExternalCaseFormattedDataObject obj = new ExternalCaseFormattedDataObject();
+    JsonObject expected = new JsonObject()
+      .put("foo", "val1")
+      .put("foofooBar", "val2")
+      .put("foofooBarfooJuu", "val3");
+    ExternalCaseFormattedDataObjectConverter.fromJson(expected, obj);
+    Assert.assertEquals("val1", obj.getFoo());
+    Assert.assertEquals("val2", obj.getFooBar());
+    Assert.assertEquals("val3", obj.getFooBarJuu());
+    JsonObject test = new JsonObject();
+    ExternalCaseFormattedDataObjectConverter.toJson(obj, test);
+    Assert.assertEquals(expected, test);
+  }
+
+  @Test
   public void testBase64Basic() {
     TestDataObjectBase64Basic obj = new TestDataObjectBase64Basic();
     JsonObject expected = new JsonObject()

--- a/vertx-codegen-json/src/test/java/io/vertx/test/codegen/converter/ExternalCaseFormattedDataObject.java
+++ b/vertx-codegen-json/src/test/java/io/vertx/test/codegen/converter/ExternalCaseFormattedDataObject.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.test.codegen.converter;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.format.SnakeCase;
+import io.vertx.core.json.JsonObject;
+import io.vertx.test.codegen.format.FooCase;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@DataObject(generateConverter = true, jsonPropertyNameFormatter = FooCase.class)
+public class ExternalCaseFormattedDataObject {
+
+  private String foo;
+  private String fooBar;
+  private String fooBarJuu;
+
+  public ExternalCaseFormattedDataObject() {
+  }
+
+  public ExternalCaseFormattedDataObject(JsonObject json) {
+  }
+
+  public String getFoo() {
+    return foo;
+  }
+
+  public ExternalCaseFormattedDataObject setFoo(String foo) {
+    this.foo = foo;
+    return this;
+  }
+
+  public String getFooBar() {
+    return fooBar;
+  }
+
+  public ExternalCaseFormattedDataObject setFooBar(String fooBar) {
+    this.fooBar = fooBar;
+    return this;
+  }
+
+  public String getFooBarJuu() {
+    return fooBarJuu;
+  }
+
+  public ExternalCaseFormattedDataObject setFooBarJuu(String fooBarJuu) {
+    this.fooBarJuu = fooBarJuu;
+    return this;
+  }
+}

--- a/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/format/FooCase.java
+++ b/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/format/FooCase.java
@@ -1,0 +1,21 @@
+package io.vertx.test.codegen.format;
+
+import io.vertx.codegen.format.Case;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Chain everything with foo
+ */
+public class FooCase extends Case {
+
+  @Override
+  public String format(Iterable<String> atoms) {
+    List<String> names = new ArrayList<>();
+    for (String s : atoms) {
+      names.add(s);
+    }
+    return String.join("foo", names);
+  }
+}


### PR DESCRIPTION
The dataobject json generator hardcodes the list of case it can support. When it resolves a case that is not supported, it simply throws an exception.

We should support loading of external cases.

