### PR TITLE
BugFix: add support for JsonArray field defined in DataObject

### DIFF
--- a/vertx-codegen-protobuf/src/converters/generated/dataobjects.proto
+++ b/vertx-codegen-protobuf/src/converters/generated/dataobjects.proto
@@ -52,14 +52,15 @@ message User {
   io.vertx.protobuf.ZonedDateTime zonedDateTimeField = 20;
   io.vertx.protobuf.Instant instantField = 21;
   io.vertx.protobuf.Struct jsonObjectField = 22;
-  bool primitiveBoolean = 23;
-  int32 primitiveByte = 24;
-  int32 primitiveShort = 25;
-  int32 primitiveInt = 26;
-  int64 primitiveLong = 27;
-  float primitiveFloat = 28;
-  double primitiveDouble = 29;
-  int32 primitiveChar = 30;
-  EnumType enumType = 31;
+  io.vertx.protobuf.ListValue jsonArrayField = 23;
+  bool primitiveBoolean = 24;
+  int32 primitiveByte = 25;
+  int32 primitiveShort = 26;
+  int32 primitiveInt = 27;
+  int64 primitiveLong = 28;
+  float primitiveFloat = 29;
+  double primitiveDouble = 30;
+  int32 primitiveChar = 31;
+  EnumType enumType = 32;
 }
 

--- a/vertx-codegen-protobuf/src/converters/generated/io/vertx/test/codegen/converter/UserProtoConverter.java
+++ b/vertx-codegen-protobuf/src/converters/generated/io/vertx/test/codegen/converter/UserProtoConverter.java
@@ -217,39 +217,46 @@ public class UserProtoConverter {
           input.popLimit(limit);
           break;
         }
-        case 184: {
-          obj.setPrimitiveBoolean(input.readBool());
+        case 186: {
+          int length = input.readUInt32();
+          int limit = input.pushLimit(length);
+          obj.setJsonArrayField(VertxStructListProtoConverter.fromProto(input));
+          input.popLimit(limit);
           break;
         }
         case 192: {
-          obj.setPrimitiveByte((byte) input.readInt32());
+          obj.setPrimitiveBoolean(input.readBool());
           break;
         }
         case 200: {
-          obj.setPrimitiveShort((short) input.readInt32());
+          obj.setPrimitiveByte((byte) input.readInt32());
           break;
         }
         case 208: {
-          obj.setPrimitiveInt(input.readInt32());
+          obj.setPrimitiveShort((short) input.readInt32());
           break;
         }
         case 216: {
+          obj.setPrimitiveInt(input.readInt32());
+          break;
+        }
+        case 224: {
           obj.setPrimitiveLong(input.readInt64());
           break;
         }
-        case 229: {
+        case 237: {
           obj.setPrimitiveFloat(input.readFloat());
           break;
         }
-        case 233: {
+        case 241: {
           obj.setPrimitiveDouble(input.readDouble());
           break;
         }
-        case 240: {
+        case 248: {
           obj.setPrimitiveChar((char) input.readInt32());
           break;
         }
-        case 248: {
+        case 256: {
           switch (input.readEnum()) {
             case 0:
               obj.setEnumType(EnumType.A);
@@ -458,40 +465,45 @@ public class UserProtoConverter {
       output.writeUInt32NoTag(VertxStructProtoConverter.computeSize(obj.getJsonObjectField()));
       VertxStructProtoConverter.toProto(obj.getJsonObjectField(), output);
     }
+    if (obj.getJsonArrayField() != null) {
+      output.writeUInt32NoTag(186);
+      output.writeUInt32NoTag(VertxStructListProtoConverter.computeSize(obj.getJsonArrayField()));
+      VertxStructListProtoConverter.toProto(obj.getJsonArrayField(), output);
+    }
     if (obj.isPrimitiveBoolean()) {
-      output.writeBool(23, obj.isPrimitiveBoolean());
+      output.writeBool(24, obj.isPrimitiveBoolean());
     }
     if (obj.getPrimitiveByte() != 0) {
-      output.writeInt32(24, obj.getPrimitiveByte());
+      output.writeInt32(25, obj.getPrimitiveByte());
     }
     if (obj.getPrimitiveShort() != 0) {
-      output.writeInt32(25, obj.getPrimitiveShort());
+      output.writeInt32(26, obj.getPrimitiveShort());
     }
     if (obj.getPrimitiveInt() != 0) {
-      output.writeInt32(26, obj.getPrimitiveInt());
+      output.writeInt32(27, obj.getPrimitiveInt());
     }
     if (obj.getPrimitiveLong() != 0) {
-      output.writeInt64(27, obj.getPrimitiveLong());
+      output.writeInt64(28, obj.getPrimitiveLong());
     }
     if (obj.getPrimitiveFloat() != 0) {
-      output.writeFloat(28, obj.getPrimitiveFloat());
+      output.writeFloat(29, obj.getPrimitiveFloat());
     }
     if (obj.getPrimitiveDouble() != 0) {
-      output.writeDouble(29, obj.getPrimitiveDouble());
+      output.writeDouble(30, obj.getPrimitiveDouble());
     }
     if (obj.getPrimitiveChar() != 0) {
-      output.writeInt32(30, obj.getPrimitiveChar());
+      output.writeInt32(31, obj.getPrimitiveChar());
     }
     if (obj.getEnumType() != null) {
       switch (obj.getEnumType()) {
         case A:
-          output.writeEnum(31, 0);
+          output.writeEnum(32, 0);
           break;
         case B:
-          output.writeEnum(31, 1);
+          output.writeEnum(32, 1);
           break;
         case C:
-          output.writeEnum(31, 2);
+          output.writeEnum(32, 2);
           break;
       }
     }
@@ -693,40 +705,46 @@ public class UserProtoConverter {
       size += CodedOutputStream.computeUInt32SizeNoTag(dataSize);
       size += dataSize;
     }
+    if (obj.getJsonArrayField() != null) {
+      size += CodedOutputStream.computeUInt32SizeNoTag(186);
+      int dataSize = VertxStructListProtoConverter.computeSize(obj.getJsonArrayField());
+      size += CodedOutputStream.computeUInt32SizeNoTag(dataSize);
+      size += dataSize;
+    }
     if (obj.isPrimitiveBoolean()) {
-      size += CodedOutputStream.computeBoolSize(23, obj.isPrimitiveBoolean());
+      size += CodedOutputStream.computeBoolSize(24, obj.isPrimitiveBoolean());
     }
     if (obj.getPrimitiveByte() != 0) {
-      size += CodedOutputStream.computeInt32Size(24, obj.getPrimitiveByte());
+      size += CodedOutputStream.computeInt32Size(25, obj.getPrimitiveByte());
     }
     if (obj.getPrimitiveShort() != 0) {
-      size += CodedOutputStream.computeInt32Size(25, obj.getPrimitiveShort());
+      size += CodedOutputStream.computeInt32Size(26, obj.getPrimitiveShort());
     }
     if (obj.getPrimitiveInt() != 0) {
-      size += CodedOutputStream.computeInt32Size(26, obj.getPrimitiveInt());
+      size += CodedOutputStream.computeInt32Size(27, obj.getPrimitiveInt());
     }
     if (obj.getPrimitiveLong() != 0) {
-      size += CodedOutputStream.computeInt64Size(27, obj.getPrimitiveLong());
+      size += CodedOutputStream.computeInt64Size(28, obj.getPrimitiveLong());
     }
     if (obj.getPrimitiveFloat() != 0) {
-      size += CodedOutputStream.computeFloatSize(28, obj.getPrimitiveFloat());
+      size += CodedOutputStream.computeFloatSize(29, obj.getPrimitiveFloat());
     }
     if (obj.getPrimitiveDouble() != 0) {
-      size += CodedOutputStream.computeDoubleSize(29, obj.getPrimitiveDouble());
+      size += CodedOutputStream.computeDoubleSize(30, obj.getPrimitiveDouble());
     }
     if (obj.getPrimitiveChar() != 0) {
-      size += CodedOutputStream.computeInt32Size(30, obj.getPrimitiveChar());
+      size += CodedOutputStream.computeInt32Size(31, obj.getPrimitiveChar());
     }
     if (obj.getEnumType() != null) {
       switch (obj.getEnumType()) {
         case A:
-          size += CodedOutputStream.computeEnumSize(31, 0);
+          size += CodedOutputStream.computeEnumSize(32, 0);
           break;
         case B:
-          size += CodedOutputStream.computeEnumSize(31, 1);
+          size += CodedOutputStream.computeEnumSize(32, 1);
           break;
         case C:
-          size += CodedOutputStream.computeEnumSize(31, 2);
+          size += CodedOutputStream.computeEnumSize(32, 2);
           break;
       }
     }

--- a/vertx-codegen-protobuf/src/converters/java/io/vertx/test/codegen/converter/User.java
+++ b/vertx-codegen-protobuf/src/converters/java/io/vertx/test/codegen/converter/User.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.protobuf.annotations.ProtobufGen;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.time.Instant;
@@ -35,6 +36,7 @@ public class User {
   private ZonedDateTime zonedDateTimeField;
   private Instant instantField;
   private JsonObject jsonObjectField;
+  private JsonArray jsonArrayField;
   private boolean primitiveBoolean;
   private byte primitiveByte;
   private short primitiveShort;
@@ -221,6 +223,14 @@ public class User {
     this.jsonObjectField = jsonObjectField;
   }
 
+  public JsonArray getJsonArrayField() {
+    return jsonArrayField;
+  }
+
+  public void setJsonArrayField(JsonArray jsonArrayField) {
+    this.jsonArrayField = jsonArrayField;
+  }
+
   public boolean isPrimitiveBoolean() {
     return primitiveBoolean;
   }
@@ -298,11 +308,11 @@ public class User {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     User user = (User) o;
-    return primitiveBoolean == user.primitiveBoolean && primitiveByte == user.primitiveByte && primitiveShort == user.primitiveShort && primitiveInt == user.primitiveInt && primitiveLong == user.primitiveLong && Float.compare(primitiveFloat, user.primitiveFloat) == 0 && Double.compare(primitiveDouble, user.primitiveDouble) == 0 && primitiveChar == user.primitiveChar && Objects.equals(userName, user.userName) && Objects.equals(age, user.age) && Objects.equals(integerListField, user.integerListField) && Objects.equals(structListField, user.structListField) && Objects.equals(zonedDateTimeListField, user.zonedDateTimeListField) && Objects.equals(jsonListField, user.jsonListField) && Objects.equals(address, user.address) && Objects.equals(byteField, user.byteField) && Objects.equals(doubleField, user.doubleField) && Objects.equals(floatField, user.floatField) && Objects.equals(longField, user.longField) && Objects.equals(boolField, user.boolField) && Objects.equals(shortField, user.shortField) && Objects.equals(charField, user.charField) && Objects.equals(stringValueMap, user.stringValueMap) && Objects.equals(integerValueMap, user.integerValueMap) && Objects.equals(structValueMap, user.structValueMap) && Objects.equals(jsonValueMap, user.jsonValueMap) && Objects.equals(zonedDateTimeValueMap, user.zonedDateTimeValueMap) && Objects.equals(zonedDateTimeField, user.zonedDateTimeField) && Objects.equals(instantField, user.instantField) && Objects.equals(jsonObjectField, user.jsonObjectField) && enumType == user.enumType;
+    return primitiveBoolean == user.primitiveBoolean && primitiveByte == user.primitiveByte && primitiveShort == user.primitiveShort && primitiveInt == user.primitiveInt && primitiveLong == user.primitiveLong && Float.compare(primitiveFloat, user.primitiveFloat) == 0 && Double.compare(primitiveDouble, user.primitiveDouble) == 0 && primitiveChar == user.primitiveChar && Objects.equals(userName, user.userName) && Objects.equals(age, user.age) && Objects.equals(integerListField, user.integerListField) && Objects.equals(structListField, user.structListField) && Objects.equals(zonedDateTimeListField, user.zonedDateTimeListField) && Objects.equals(jsonListField, user.jsonListField) && Objects.equals(address, user.address) && Objects.equals(byteField, user.byteField) && Objects.equals(doubleField, user.doubleField) && Objects.equals(floatField, user.floatField) && Objects.equals(longField, user.longField) && Objects.equals(boolField, user.boolField) && Objects.equals(shortField, user.shortField) && Objects.equals(charField, user.charField) && Objects.equals(stringValueMap, user.stringValueMap) && Objects.equals(integerValueMap, user.integerValueMap) && Objects.equals(structValueMap, user.structValueMap) && Objects.equals(jsonValueMap, user.jsonValueMap) && Objects.equals(zonedDateTimeValueMap, user.zonedDateTimeValueMap) && Objects.equals(zonedDateTimeField, user.zonedDateTimeField) && Objects.equals(instantField, user.instantField) && Objects.equals(jsonObjectField, user.jsonObjectField) && Objects.equals(jsonArrayField, user.jsonArrayField) && enumType == user.enumType;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(userName, age, integerListField, structListField, zonedDateTimeListField, jsonListField, address, byteField, doubleField, floatField, longField, boolField, shortField, charField, stringValueMap, integerValueMap, structValueMap, jsonValueMap, zonedDateTimeValueMap, zonedDateTimeField, instantField, jsonObjectField, primitiveBoolean, primitiveByte, primitiveShort, primitiveInt, primitiveLong, primitiveFloat, primitiveDouble, primitiveChar, enumType);
+    return Objects.hash(userName, age, integerListField, structListField, zonedDateTimeListField, jsonListField, address, byteField, doubleField, floatField, longField, boolField, shortField, charField, stringValueMap, integerValueMap, structValueMap, jsonValueMap, zonedDateTimeValueMap, zonedDateTimeField, instantField, jsonObjectField, jsonArrayField, primitiveBoolean, primitiveByte, primitiveShort, primitiveInt, primitiveLong, primitiveFloat, primitiveDouble, primitiveChar, enumType);
   }
 }

--- a/vertx-codegen-protobuf/src/main/java/io/vertx/codegen/protobuf/generator/ProtoFileGen.java
+++ b/vertx-codegen-protobuf/src/main/java/io/vertx/codegen/protobuf/generator/ProtoFileGen.java
@@ -33,9 +33,8 @@ public class ProtoFileGen extends Generator<Model> {
 
   @Override
   public String filename(Model model) {
-    System.out.println("INSPECTING " + model.getAnnotations());
-    if ((model instanceof DataObjectModel || model instanceof EnumModel) && model.getAnnotations().stream().anyMatch(ann -> ann.getName().equals(ProtobufGen.class.getName()))) {
-      System.out.println("TRIGGERED");
+    if ((model instanceof DataObjectModel || model instanceof EnumModel)
+      && model.getAnnotations().stream().anyMatch(ann -> ann.getName().equals(ProtobufGen.class.getName()))) {
       return "resources/dataobjects.proto";
     }
     return null;

--- a/vertx-codegen-protobuf/src/main/java/io/vertx/codegen/protobuf/generator/ProtoProperty.java
+++ b/vertx-codegen-protobuf/src/main/java/io/vertx/codegen/protobuf/generator/ProtoProperty.java
@@ -132,6 +132,8 @@ public class ProtoProperty {
         return "Instant";
       case "io.vertx.core.json.JsonObject":
         return "Struct";
+      case "io.vertx.core.json.JsonArray":
+        return "ListValue";
       default:
         return null;
     }
@@ -149,6 +151,15 @@ public class ProtoProperty {
             return "VertxStructProtoConverter";
           case GOOGLE_STRUCT:
             return "GoogleStructProtoConverter";
+          default:
+            throw new InternalError("Unknown built-it type " + builtInType);
+        }
+      case "JsonArray":
+        switch (jsonProtoEncoding) {
+          case VERTX_STRUCT:
+            return "VertxStructListProtoConverter";
+          case GOOGLE_STRUCT:
+            return "GoogleStructListProtoConverter";
           default:
             throw new InternalError("Unknown built-it type " + builtInType);
         }

--- a/vertx-codegen-protobuf/src/main/resources/proto/vertx-struct.proto
+++ b/vertx-codegen-protobuf/src/main/resources/proto/vertx-struct.proto
@@ -15,7 +15,7 @@ message Value {
   oneof kind {
     NullValue null_value = 1;
     Struct json_object_value = 2;
-    ListStruct json_array_value = 3;
+    ListValue json_array_value = 3;
     bool bool_value = 4;
     string string_value = 5;
     int32 integer_value = 6;
@@ -31,6 +31,6 @@ enum NullValue {
   NULL_VALUE = 0;
 }
 
-message ListStruct {
+message ListValue {
   repeated Value values = 1;
 }

--- a/vertx-codegen-protobuf/src/test/java/io/vertx/test/codegen/protobuf/GoogleStructProtoTest.java
+++ b/vertx-codegen-protobuf/src/test/java/io/vertx/test/codegen/protobuf/GoogleStructProtoTest.java
@@ -157,11 +157,11 @@ public class GoogleStructProtoTest {
     strJsonArray.add("Three");
     jsonObject.put("strList", strJsonArray);
 
-    JsonArray longJsonARray = new JsonArray();
-    longJsonARray.add(1000L);
-    longJsonARray.add(2000L);
-    longJsonARray.add(3000L);
-    jsonObject.put("longList", longJsonARray);
+    JsonArray longJsonArray = new JsonArray();
+    longJsonArray.add(1000L);
+    longJsonArray.add(2000L);
+    longJsonArray.add(3000L);
+    jsonObject.put("longList", longJsonArray);
 
     JsonArray jsonArray = new JsonArray();
     jsonArray.add(new JsonObject().put("Key1", "Value1"));

--- a/vertx-codegen-protobuf/src/test/java/io/vertx/test/codegen/protobuf/ProtoConverterTest.java
+++ b/vertx-codegen-protobuf/src/test/java/io/vertx/test/codegen/protobuf/ProtoConverterTest.java
@@ -3,6 +3,7 @@ package io.vertx.test.codegen.protobuf;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.InvalidProtocolBufferException;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.codegen.converter.Address;
 import io.vertx.test.codegen.converter.EnumType;
@@ -70,10 +71,16 @@ public class ProtoConverterTest {
     user.setAddress(address1);
 
     // Built-in Object fields
-    JsonObject jsonObject5 = new JsonObject();
-    jsonObject5.put("IntField", 105);
-    jsonObject5.put("StringField", "StringValue-5");
-    user.setJsonObjectField(jsonObject5);
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.put("IntField", 105);
+    jsonObject.put("StringField", "StringValue-5");
+    user.setJsonObjectField(jsonObject);
+
+    JsonArray intJsonArray = new JsonArray();
+    intJsonArray.add("One");
+    intJsonArray.add("Two");
+    intJsonArray.add("Three");
+    user.setJsonArrayField(intJsonArray);
 
     // Enum fields
     user.setEnumType(EnumType.C);
@@ -143,6 +150,7 @@ public class ProtoConverterTest {
 
     // Built-in Object fields
     assertEquals(user.getJsonObjectField(), decoded.getJsonObjectField());
+    assertArrayEquals(user.getJsonArrayField().getList().toArray(), decoded.getJsonArrayField().getList().toArray());
 
     // Enum fields
     assertEquals(protocObj.getEnumType().getNumber(), 2); // EnumType.C

--- a/vertx-codegen-protobuf/src/test/java/io/vertx/test/codegen/protobuf/VertxStructProtoTest.java
+++ b/vertx-codegen-protobuf/src/test/java/io/vertx/test/codegen/protobuf/VertxStructProtoTest.java
@@ -128,11 +128,11 @@ public class VertxStructProtoTest {
   public void TestJsonArray() throws IOException {
     JsonObject jsonObject = new JsonObject();
 
-    JsonArray intJsonARray = new JsonArray();
-    intJsonARray.add(1);
-    intJsonARray.add(2);
-    intJsonARray.add(3);
-    jsonObject.put("intList", intJsonARray);
+    JsonArray intJsonArray = new JsonArray();
+    intJsonArray.add(1);
+    intJsonArray.add(2);
+    intJsonArray.add(3);
+    jsonObject.put("intList", intJsonArray);
 
     JsonArray strJsonArray = new JsonArray();
     strJsonArray.add("One");
@@ -140,11 +140,11 @@ public class VertxStructProtoTest {
     strJsonArray.add("Three");
     jsonObject.put("strList", strJsonArray);
 
-    JsonArray longJsonARray = new JsonArray();
-    longJsonARray.add(1000L);
-    longJsonARray.add(2000L);
-    longJsonARray.add(3000L);
-    jsonObject.put("longList", longJsonARray);
+    JsonArray longJsonArray = new JsonArray();
+    longJsonArray.add(1000L);
+    longJsonArray.add(2000L);
+    longJsonArray.add(3000L);
+    jsonObject.put("longList", longJsonArray);
 
     byte[] encoded = vertxEncode(jsonObject);
 


### PR DESCRIPTION
`JsonArray` field type is only handled by `JsonObject`. This PR adds support for handling a `JsonArray` field when it is defined in a `DataObject` POJO.