### PR TITLE
Add support of unbounded wildcard types to GenIgnore permitted types

### DIFF
--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
@@ -79,6 +79,8 @@ public class TypeMirrorFactory {
         return create(use, (TypeVariable) type);
       case ARRAY:
         return create(use, (ArrayType) type);
+      case WILDCARD:
+        return WildcardTypeInfo.INSTANCE;
       default:
         throw new IllegalArgumentException("Illegal type " + type + " of kind " + type.getKind());
     }

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/type/TypeReflectionFactory.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/type/TypeReflectionFactory.java
@@ -104,6 +104,8 @@ public class TypeReflectionFactory {
       java.lang.reflect.TypeVariable typeVar = (java.lang.reflect.TypeVariable) type;
       TypeParamInfo param = TypeParamInfo.create(typeVar);
       return new TypeVariableInfo(param, false, ((java.lang.reflect.TypeVariable) type).getName());
+    } else if (type instanceof WildcardType) {
+      return WildcardTypeInfo.INSTANCE;
     } else {
       throw new IllegalArgumentException("Unsupported type " + type);
     }

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/type/WildcardTypeInfo.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/type/WildcardTypeInfo.java
@@ -1,0 +1,24 @@
+package io.vertx.codegen.type;
+
+public class WildcardTypeInfo extends TypeInfo {
+
+  public static final WildcardTypeInfo INSTANCE = new WildcardTypeInfo();
+
+  private WildcardTypeInfo() {
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj == this;
+  }
+
+  @Override
+  public ClassKind getKind() {
+    return ClassKind.OTHER;
+  }
+
+  @Override
+  String format(boolean qualified) {
+    return "?";
+  }
+}

--- a/vertx-codegen-processor/src/tck/java/io/vertx/codegen/testmodel/AnyJavaTypeTCK.java
+++ b/vertx-codegen-processor/src/tck/java/io/vertx/codegen/testmodel/AnyJavaTypeTCK.java
@@ -17,20 +17,23 @@ public interface AnyJavaTypeTCK {
   @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithListOfJavaTypeParam(List<Socket> socketList);
   @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithSetOfJavaTypeParam(Set<Socket> socketSet);
   @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithMapOfJavaTypeParam(Map<String, Socket> socketMap);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithGenericWithWildcard(Iterable<?> iterable);
 
   @GenIgnore(GenIgnore.PERMITTED_TYPE) Socket methodWithJavaTypeReturn();
   @GenIgnore(GenIgnore.PERMITTED_TYPE) List<Socket> methodWithListOfJavaTypeReturn();
   @GenIgnore(GenIgnore.PERMITTED_TYPE) Set<Socket> methodWithSetOfJavaTypeReturn();
   @GenIgnore(GenIgnore.PERMITTED_TYPE) Map<String, Socket> methodWithMapOfJavaTypeReturn();
+  @GenIgnore(GenIgnore.PERMITTED_TYPE) Iterable<?> methodWithGenericWithWildcardReturn();
 
   @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithHandlerJavaTypeParam(Handler<Socket> socketHandler);
   @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithHandlerListOfJavaTypeParam(Handler<List<Socket>> socketListHandler);
   @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithHandlerSetOfJavaTypeParam(Handler<Set<Socket>> socketSetHandler);
   @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithHandlerMapOfJavaTypeParam(Handler<Map<String, Socket>> socketMapHandler);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithHandlerGenericWithWildcardParam(Handler<Iterable<?>> iterableHandler);
 
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  Future<Socket> methodWithHandlerAsyncResultJavaTypeParam();
+  @GenIgnore(GenIgnore.PERMITTED_TYPE) Future<Socket> methodWithHandlerAsyncResultJavaTypeParam();
   @GenIgnore(GenIgnore.PERMITTED_TYPE) Future<List<Socket>> methodWithHandlerAsyncResultListOfJavaTypeParam();
   @GenIgnore(GenIgnore.PERMITTED_TYPE) Future<Set<Socket>> methodWithHandlerAsyncResultSetOfJavaTypeParam();
   @GenIgnore(GenIgnore.PERMITTED_TYPE) Future<Map<String, Socket>> methodWithHandlerAsyncResultMapOfJavaTypeParam();
+  @GenIgnore(GenIgnore.PERMITTED_TYPE) Future<Iterable<?>> methodWithHandlerAsyncResultGenericWithWildcardParam();
 }

--- a/vertx-codegen-processor/src/tck/java/io/vertx/codegen/testmodel/AnyJavaTypeTCKImpl.java
+++ b/vertx-codegen-processor/src/tck/java/io/vertx/codegen/testmodel/AnyJavaTypeTCKImpl.java
@@ -4,12 +4,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
 import java.net.Socket;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.Assert.*;
 
@@ -42,6 +37,13 @@ public class AnyJavaTypeTCKImpl implements AnyJavaTypeTCK {
   }
 
   @Override
+  public void methodWithGenericWithWildcard(Iterable<?> iterable) {
+    iterable.forEach(o -> {
+      assertNotNull(o);
+    });
+  }
+
+  @Override
   public Socket methodWithJavaTypeReturn() {
     return new Socket();
   }
@@ -71,65 +73,61 @@ public class AnyJavaTypeTCKImpl implements AnyJavaTypeTCK {
   }
 
   @Override
+  public Iterable<?> methodWithGenericWithWildcardReturn() {
+    return Arrays.asList("A", "B", "C");
+  }
+
+  @Override
   public void methodWithHandlerJavaTypeParam(Handler<Socket> socketHandler) {
     assertNotNull(socketHandler);
-    socketHandler.handle(new Socket());
+    socketHandler.handle(methodWithJavaTypeReturn());
   }
 
   @Override
   public void methodWithHandlerListOfJavaTypeParam(Handler<List<Socket>> socketListHandler) {
     assertNotNull(socketListHandler);
-    Socket socket = new Socket();
-    ArrayList<Socket> sockets = new ArrayList<>();
-    sockets.add(socket);
-    socketListHandler.handle(sockets);
+    socketListHandler.handle(methodWithListOfJavaTypeReturn());
   }
 
   @Override
   public void methodWithHandlerSetOfJavaTypeParam(Handler<Set<Socket>> socketSetHandler) {
     assertNotNull(socketSetHandler);
-    Socket socket = new Socket();
-    Set<Socket> sockets = new HashSet<>();
-    sockets.add(socket);
-    socketSetHandler.handle(sockets);
+    socketSetHandler.handle(methodWithSetOfJavaTypeReturn());
   }
 
   @Override
   public void methodWithHandlerMapOfJavaTypeParam(Handler<Map<String, Socket>> socketMapHandler) {
     assertNotNull(socketMapHandler);
-    Socket socket = new Socket();
-    Map<String, Socket> sockets = new HashMap<>();
-    sockets.put("1", socket);
-    socketMapHandler.handle(sockets);
+    socketMapHandler.handle(methodWithMapOfJavaTypeReturn());
+  }
+
+  @Override
+  public void methodWithHandlerGenericWithWildcardParam(Handler<Iterable<?>> iterableHandler) {
+    iterableHandler.handle(methodWithGenericWithWildcardReturn());
   }
 
   @Override
   public Future<Socket> methodWithHandlerAsyncResultJavaTypeParam() {
-    Socket socket = new Socket();
-    return Future.succeededFuture(socket);
+    return Future.succeededFuture(methodWithJavaTypeReturn());
   }
 
   @Override
   public Future<List<Socket>> methodWithHandlerAsyncResultListOfJavaTypeParam() {
-    Socket socket = new Socket();
-    ArrayList<Socket> sockets = new ArrayList<>();
-    sockets.add(socket);
-    return Future.succeededFuture(sockets);
+    return Future.succeededFuture(methodWithListOfJavaTypeReturn());
   }
 
   @Override
   public Future<Set<Socket>> methodWithHandlerAsyncResultSetOfJavaTypeParam() {
-    Socket socket = new Socket();
-    Set<Socket> sockets = new HashSet<>();
-    sockets.add(socket);
-    return Future.succeededFuture(sockets);
+    return Future.succeededFuture(methodWithSetOfJavaTypeReturn());
   }
 
   @Override
   public Future<Map<String, Socket>> methodWithHandlerAsyncResultMapOfJavaTypeParam() {
-    Socket socket = new Socket();
-    Map<String, Socket> sockets = new HashMap<>();
-    sockets.put("1", socket);
-    return Future.succeededFuture(sockets);
+    return Future.succeededFuture(methodWithMapOfJavaTypeReturn());
+  }
+
+  @Override
+  public Future<Iterable<?>> methodWithHandlerAsyncResultGenericWithWildcardParam() {
+    return Future.succeededFuture(methodWithGenericWithWildcardReturn());
   }
 }

--- a/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/ClassTest.java
+++ b/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/ClassTest.java
@@ -790,7 +790,7 @@ public class ClassTest extends ClassTestBase {
   @Test
   public void testValidJavaTypeParams() throws Exception {
     ClassModel model = new GeneratorHelper().generateClass(MethodWithValidJavaTypeParams.class);
-    assertEquals(6, model.getAnyJavaTypeMethods().size());
+    assertEquals(7, model.getAnyJavaTypeMethods().size());
 
     MethodInfo method = model.getAnyJavaTypeMethods().get(0);
     checkMethod(method, "methodWithParams", 4, "void", MethodKind.OTHER);
@@ -839,6 +839,12 @@ public class ClassTest extends ClassTestBase {
     checkMethod(method, "methodWithParameterizedParams", 1, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "iterableString", new TypeLiteral<Iterable<String>>(){});
+    assertTrue(method.isContainingAnyJavaType());
+
+    method = model.getAnyJavaTypeMethods().get(6);
+    checkMethod(method, "methodWithWildcardType", 1, "void", MethodKind.OTHER);
+    params = method.getParams();
+    checkParam(params.get(0), "listOfUnknown", new TypeLiteral<List<?>>(){});
     assertTrue(method.isContainingAnyJavaType());
   }
 

--- a/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/testapi/javatypes/MethodWithValidJavaTypeParams.java
+++ b/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/testapi/javatypes/MethodWithValidJavaTypeParams.java
@@ -66,4 +66,6 @@ public interface MethodWithValidJavaTypeParams {
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   void methodWithParameterizedParams(Iterable<String> iterableString);
 
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  void methodWithWildcardType(List<?> listOfUnknown);
 }


### PR DESCRIPTION
It's useful to declare `@GenIgnore(GenIgnore.PERMITTED_TYPE) void foo(Iterable<?>)`