### PR TITLE
Add a @JsonGen annotation that replaces the @DataObject converter generation

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -165,7 +165,7 @@ com.example.MyEnumWithCustomFactory.deserializer=com.example.MyEnumWithCustomFac
 
 A `@DataObject` annotated type is a Java class with the only purpose to be a container for data.
 
-A converter instance is automatically generated when the class is annotated with `@DataObject(generateConverter = true)`
+A converter instance is automatically generated when the class is annotated with `@DataObject` and `@JsonGen`
 
 Data object annotated classes can also inherit from other data objects annotated types.
 
@@ -258,9 +258,9 @@ The data object/json conversion can be tedious and error prone.
 Vertx-codegen can automate it, generating for you an auxiliary class that implements the conversion logic.
 The generated converter handles the type mapping as well as the json naming convention.
 
-Converters are generated when the data object is annotated with `@DataObject(generateConverter=true)`. The
+Converters are generated when the data object is annotated with `@DataObject` and `@JsonGen`. The
 generation happens for the data object properties, not for the ancestor properties, unless `inheritConverter`
-is set: `@DataObject(generateConverter=true,inheritConverter=true)`.
+is set: `@JsonGen(generateConverter=true,inheritConverter=true)`.
 
 The converter is named by appending the `Converter` suffix to the data object class name, e.g,
 `ContactDetails` -> `ContactDetailsConverter`. The generated converter has two static methods:

--- a/src/main/java/io/vertx/codegen/DataObjectModel.java
+++ b/src/main/java/io/vertx/codegen/DataObjectModel.java
@@ -2,6 +2,7 @@ package io.vertx.codegen;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.JsonGen;
 import io.vertx.codegen.doc.Doc;
 import io.vertx.codegen.doc.Tag;
 import io.vertx.codegen.doc.Text;
@@ -227,12 +228,21 @@ public class DataObjectModel implements Model {
     return false;
   }
 
+  @SuppressWarnings("deprecation")
   private void traverse() {
     DataObject ann = modelElt.getAnnotation(DataObject.class);
-    this.generateConverter = ann.generateConverter();
-    this.publicConverter = ann.publicConverter();
-    this.inheritConverter = ann.inheritConverter();
-    this.base64Type = ann.base64Type();
+    JsonGen jsonGen = modelElt.getAnnotation(JsonGen.class);
+    if (jsonGen != null) {
+      this.generateConverter = true;
+      this.publicConverter = jsonGen.publicConverter();
+      this.inheritConverter = jsonGen.inheritConverter();
+      this.base64Type = jsonGen.base64Type();
+    } else {
+      this.generateConverter = ann.generateConverter();
+      this.publicConverter = ann.publicConverter();
+      this.inheritConverter = ann.inheritConverter();
+      this.base64Type = ann.base64Type();
+    }
     if (base64Type == null) {
       throw new GenException(modelElt, "Data object base64 type cannot be null");
     } else {

--- a/src/main/java/io/vertx/codegen/annotations/DataObject.java
+++ b/src/main/java/io/vertx/codegen/annotations/DataObject.java
@@ -45,16 +45,6 @@ import java.lang.annotation.Target;
  * Sometimes data object can have a {@code toJson()} method that takes no arguments and returns a {@code JsonObject} representing
  * the data object as a {@code JsonObject}.<p/>
  *
- * Vert.x core will generate a json converters using annotation processing to ease conversion, for a given data object,
- * a converter is generated, the name of this converter is the name of the data object with the {@literal Converter} suffix.<p/>
- *
- * The converter has a {@code fromJson(JsonObject,T)} and a {@code toJson(T,JsonObject)} public static methods, such methods
- * can be used by the json constructor or the {@code toJson()} method to implement the conversion code. By default the
- * generated methods only handle the conversion of the property of the data object and do not handle the properties of the
- * ancestors of this data object, {@link #inheritConverter()} can be set to true to change this behavior and handle the
- * conversion of the inherited properties as well. The converter generation can be prevented with the
- * {@link #generateConverter()} annotation member.
- *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -63,22 +53,30 @@ public @interface DataObject {
 
   /**
    * @return true if converter should be generated for the data object
+   * @deprecated instead declare a {@link JsonGen} annotation
    */
+  @Deprecated
   boolean generateConverter() default false;
 
   /**
    * @return true if the converter should handle the state of the ancestors.
+   * @deprecated instead declare a {@link JsonGen#inheritConverter()}
    */
+  @Deprecated
   boolean inheritConverter() default false;
 
   /**
    * @return whether the generated converter should be public or package private
+   * @deprecated instead declare a {@link JsonGen#publicConverter()}
    */
+  @Deprecated
   boolean publicConverter() default true;
 
   /**
-   * @return todo
+   * @return the case class specifying how the data object converter properties will be translated to JSON element names.
+   * @deprecated instead declare a {@link JsonGen#jsonPropertyNameFormatter()}
    */
+  @Deprecated
   Class<? extends Case> jsonPropertyNameFormatter() default LowerCamelCase.class;
 
   /**
@@ -95,6 +93,8 @@ public @interface DataObject {
    * </ul>
    *
    * @return if generated converters are enabled, buffers should default to the configured type.
+   * @deprecated instead declare a {@link JsonGen#base64Type()}
    */
+  @Deprecated
   String base64Type() default "";
 }

--- a/src/main/java/io/vertx/codegen/annotations/JsonGen.java
+++ b/src/main/java/io/vertx/codegen/annotations/JsonGen.java
@@ -1,0 +1,55 @@
+package io.vertx.codegen.annotations;
+
+import io.vertx.codegen.format.Case;
+import io.vertx.codegen.format.LowerCamelCase;
+
+/**
+ * Annotation for {@link io.vertx.codegen.annotations.DataObject} annotated class that triggers
+ * the generation of a converter class that performs from/to JSON conversion based on the
+ * data object properties.
+ *
+ * <p>The name of this converter is the name of the data object with the {@literal Converter} suffix.
+ *
+ * <p>The converter has a {@code fromJson(JsonObject,T)} and a {@code toJson(T,JsonObject)} public static methods, such methods
+ * can be used by the json constructor or the {@code toJson()} method to implement the conversion code.
+ *
+ * <p>By default, the generated methods only handle the conversion of the property of the data object and do not
+ * handle the properties of the ancestors of this data object, {@link #inheritConverter()} can be set to
+ * true to change this behavior and handle the conversion of the inherited properties as well.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public @interface JsonGen {
+
+  /**
+   * @return true if the converter should handle the state of the ancestors.
+   */
+  boolean inheritConverter() default false;
+
+  /**
+   * @return whether the generated converter should be public or package private
+   */
+  boolean publicConverter() default true;
+
+  /**
+   * @return todo
+   */
+  Class<? extends Case> jsonPropertyNameFormatter() default LowerCamelCase.class;
+
+  /**
+   * Returns the expected Base64 (RFC 4648) type to be used. When omitted, his is
+   * vert.x default alphabet, usually (RFC 4648 Table 2) also known as {@code base64url}, unless the
+   * system property {@code vertx.json.base64} is {@code legacy}. In this case the alphabet will
+   * be {@code basic} as it was during the vert.x 3.x releases.
+   *
+   * Allowed values are:
+   *
+   * <ul>
+   *   <li>{@code "base64url"} - Base64 URL and Filename Safe as defined in (RFC 4648 Table 2) </li>
+   *   <li>{@code "basic"} - Base64 Basic as defined in (RFC 4648 Table 1) </li>
+   * </ul>
+   *
+   * @return if generated converters are enabled, buffers should default to the configured type.
+   */
+  String base64Type() default "";
+}


### PR DESCRIPTION
The `@DataObject` members are deprecated in favour of the `@JsonGen` annotation.

The new `@JsonGen` annotation triggers the generation of a converter and holds the `@DataObject` configuration.

In short:

```java
@DataObject(base64Type = "basic")
```

is replaced by

```java
@DataObject
@JsonGen(base64Type = "basic")
```

