### PR TITLE
Codegen API JPMS support

### DIFF
--- a/vertx-codegen-api/src/main/java/module-info.java
+++ b/vertx-codegen-api/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module io.vertx.codegen.api {
+  exports io.vertx.codegen.annotations;
+  exports io.vertx.codegen.format;
+}

--- a/vertx-codegen-api/src/main/resources/META-INF/MANIFEST.MF
+++ b/vertx-codegen-api/src/main/resources/META-INF/MANIFEST.MF
@@ -1,2 +1,0 @@
-Automatic-Module-Name: io.vertx.codegen.api
-


### PR DESCRIPTION
Proper JPMS module (non automatic) for io.vertx.codegen.api module, which can be imported by other modules relying on the annotations for code generation.
