### PR TITLE
JPMS support

### DIFF
--- a/vertx-codegen-api/src/main/java/module-info.java
+++ b/vertx-codegen-api/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module io.vertx.codegen.api {
+  exports io.vertx.codegen.annotations;
+  exports io.vertx.codegen.format;
+}

--- a/vertx-codegen-json/pom.xml
+++ b/vertx-codegen-json/pom.xml
@@ -28,10 +28,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>
@@ -123,6 +119,27 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <version>1.0.0.Final</version>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <module>
+                <moduleInfo>
+                  <name>io.vertx.codegen.json</name>
+                </moduleInfo>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>

--- a/vertx-codegen-json/src/main/resources/META-INF/MANIFEST.MF
+++ b/vertx-codegen-json/src/main/resources/META-INF/MANIFEST.MF
@@ -1,2 +1,0 @@
-Automatic-Module-Name: io.vertx.codegen.json
-

--- a/vertx-codegen-processor/pom.xml
+++ b/vertx-codegen-processor/pom.xml
@@ -22,10 +22,6 @@
       <artifactId>vertx-codegen-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>
@@ -111,6 +107,27 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <version>1.0.0.Final</version>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <module>
+                <moduleInfo>
+                  <name>io.vertx.codegen.processor</name>
+                </moduleInfo>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/vertx-codegen-processor/src/main/resources/META-INF/MANIFEST.MF
+++ b/vertx-codegen-processor/src/main/resources/META-INF/MANIFEST.MF
@@ -1,2 +1,0 @@
-Automatic-Module-Name: io.vertx.codegen.processor
-

--- a/vertx-codegen-protobuf/pom.xml
+++ b/vertx-codegen-protobuf/pom.xml
@@ -31,10 +31,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>${protoc.version}</version>


### PR DESCRIPTION
The _vertx-codegen-api_ declares its own module descriptor as a `module-info.java` file.

The _vertx-codegen-processor_ and _vertx-codegen-json_ modules instead rely on [moditect](https://github.com/moditect/moditect) to generate module descriptor for the sake of preserving the execution of codegen processor tests in IDE. The codegen processor is not intended to be modular, however _vertx-codegen-api_ and _vertx-codegen-json_ are actually consumed by from java modules (e.g `io.vertx.core` module).

The absence of an module-info descriptor instructs the IDE to run tests in classpath mode which is what we need, hence the moditect is a good fit.
