### PR TITLE
Remove nullable override method checks

### DIFF
--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeUse.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeUse.java
@@ -30,6 +30,7 @@ public class TypeUse {
   private static final List<TypeInternalProvider> providers = new ArrayList<>();
 
   static {
+/*
     providers.add(new TypeInternalProvider() {
       private Method getMethod(ProcessingEnvironment env, ExecutableElement methodElt) {
         Method methodRef = Helper.getReflectMethod(Thread.currentThread().getContextClassLoader(), methodElt);
@@ -55,6 +56,7 @@ public class TypeUse {
         return new ReflectType(annotated);
       }
     });
+*/
     providers.add(new TypeInternalProvider() {
       @Override
       public TypeInternal forParam(ProcessingEnvironment env, ExecutableElement methodElt, int index) {
@@ -80,8 +82,10 @@ public class TypeUse {
 
 
   public static TypeUse createParamTypeUse(ProcessingEnvironment env, ExecutableElement[] methods, int index) {
-    TypeInternal[] internals = new TypeInternal[methods.length];
-    for (int i = 0;i < methods.length;i++) {
+    // Only look at the most recent type
+    int len = Math.min(1, methods.length);
+    TypeInternal[] internals = new TypeInternal[len];
+    for (int i = 0;i < len;i++) {
       for (TypeInternalProvider provider : providers) {
         internals[i] = provider.forParam(env, methods[i], index);
         if (internals[i] != null) {
@@ -93,8 +97,10 @@ public class TypeUse {
   }
 
   public static TypeUse createReturnTypeUse(ProcessingEnvironment env, ExecutableElement... methods) {
-    TypeInternal[] internals = new TypeInternal[methods.length];
-    for (int i = 0;i < methods.length;i++) {
+    // Only look at the most recent type
+    int len = Math.min(1, methods.length);
+    TypeInternal[] internals = new TypeInternal[len];
+    for (int i = 0;i < len;i++) {
       for (TypeInternalProvider provider : providers) {
         internals[i] = provider.forReturn(env, methods[i]);
         if (internals[i] != null) {

--- a/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/ClassNullableTest.java
+++ b/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/ClassNullableTest.java
@@ -59,6 +59,7 @@ import io.vertx.test.codegen.testapi.nullable.MethodWithNullableTypeVariableHand
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableTypeVariableParam;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableTypeVariableReturn;
 import io.vertx.test.codegen.testapi.nullable.MethodWithOverloadedNullableParam;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -84,12 +85,14 @@ public class ClassNullableTest extends ClassTestBase {
     assertGenInvalid(MethodWithInvalidHandlerNullableAsyncResult.class);
   }
 
+  @Ignore("Cannot pass as we cannot rely on the type being present on the classpath and a JDK compiler bug")
   @Test
   public void testInterfaceWithInvalidNullableParamOverride() throws Exception {
     assertGenInvalid(InterfaceWithInvalidNullableParamOverride.class, InterfaceWithNonNullableParams.class);
     assertGenInvalid(InterfaceWithInvalidNullableParamOverride.class);
   }
 
+  @Ignore("Cannot pass as we cannot rely on the type being present on the classpath and a JDK compiler bug")
   @Test
   public void testInterfaceWithInvalidListNullableParamOverride() throws Exception {
     assertGenInvalid(InterfaceWithInvalidListNullableParamOverride.class, InterfaceWithNonNullableParams.class);
@@ -153,6 +156,7 @@ public class ClassNullableTest extends ClassTestBase {
     assertGenInvalid(MethodWithInvalidNullableCharReturn.class);
   }
 
+  @Ignore("Cannot pass as we cannot rely on the type being present on the classpath and a JDK compiler bug")
   @Test
   public void testInterfaceWithInvalidNullableReturnOverride() throws Exception {
     assertGenInvalid(InterfaceWithInvalidNullableReturnOverride.class);
@@ -192,6 +196,7 @@ public class ClassNullableTest extends ClassTestBase {
     }, MethodWithNullableHandler.class);
   }
 
+  @Ignore("Cannot pass as we cannot rely on the type being present on the classpath and a JDK compiler bug")
   @Test
   public void testInterfaceWithNullableParamOverride() throws Exception {
     Consumer<ClassModel> test = model -> {
@@ -204,6 +209,7 @@ public class ClassNullableTest extends ClassTestBase {
     generateClass(test, MethodWithNullableParamOverride.class);
   }
 
+  @Ignore("Cannot pass as we cannot rely on the type being present on the classpath and a JDK compiler bug")
   @Test
   public void testInterfaceWithListNullableParamOverride() throws Exception {
     generateClass(model -> {
@@ -214,6 +220,7 @@ public class ClassNullableTest extends ClassTestBase {
     }, MethodWithListNullableParamOverride.class, MethodWithListNullableParam.class);
   }
 
+  @Ignore("Cannot pass as we cannot rely on the type being present on the classpath and a JDK compiler bug")
   @Test
   public void testMethodWithNullableInheritedParams() throws Exception {
     Consumer<ClassModel> check = model -> {
@@ -228,6 +235,7 @@ public class ClassNullableTest extends ClassTestBase {
     generateClass(check, MethodWithNullableInheritedParams.class);
   }
 
+  @Ignore("Cannot pass as we cannot rely on the type being present on the classpath and a JDK compiler bug")
   @Test
   public void testMethodWithCovariantNullableReturn() throws Exception {
     Consumer<ClassModel> check = model -> {
@@ -469,6 +477,7 @@ public class ClassNullableTest extends ClassTestBase {
     });
   }
 
+  @Ignore("Cannot pass as we cannot rely on the type being present on the classpath and a JDK compiler bug")
   @Test
   public void testInterfaceWithNullableReturnOverride() throws Exception {
     generateClass(model -> {
@@ -479,6 +488,7 @@ public class ClassNullableTest extends ClassTestBase {
     }, InterfaceWithNullableReturnOverride.class, InterfaceWithNullableReturnMethod.class);
   }
 
+  @Ignore("Cannot pass as we cannot rely on the type being present on the classpath and a JDK compiler bug")
   @Test
   public void testDiamondFluentNullableReturn() throws Exception {
     ClassModel model = new GeneratorHelper().generateClass(DiamondGenericBottomFluentNullableParam.class);


### PR DESCRIPTION
The codegen processor performs `@Nullable` method override checks, e.g. the compilation fails when `(Future<String>foo)()` overrides `(Future<@Nullable String>)foo()` to ensure that we will not generate incorrect code, e.g. rx cares about this `Maybe`/`Single` are generated depending on the nullability of the argument type of the returned future.

The Java compiler unfortunately does not always provide the annotations for such types, one of them is https://bugs.openjdk.org/browse/JDK-8225377. Fortunately it has been fixed upstream and back-ported to JDK 11 (which is the baseline of this project) unfortunately it makes TypeMirror#toString() (non contractual) behave correctly now (e.g. it will return a different string containing more annotations than before). Unfortunaly the backport was reverted (https://bugs.openjdk.org/browse/JDK-8322883) because some project rely on the non contractual value returned by toString (https://bugs.openjdk.org/browse/JDK-8322641), e.g. like here https://github.com/micronaut-projects/micronaut-core/blob/97aeb96c3e2fa25e4ac51e57e52564bb9566d225/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java#L388 . Fortunately this behaviour has been reverted to fix this bug.

We have been so far using a work around to obtain the annotations from the classpath and the java class instead of the type mirror annotation. We cannot rely on this behavior anymore since we might now obtain types from the type mirror exclusively due to the adoption of JPMS.

This commit disables the overrides checks used to be done previously. Since Vert.x 4 this only matters for nullable futures returns that impact Single/Maybe generation. The main consequence of this is that now a faulty override (e.g. have `(Future<String>)foo()` overrides `(Future<@Nullable String>)foo()`) will be caught in the generator like RX instead of being caught upstream in the project containing the annotated code.
