### PR TITLE
Deprecate JsonGen base64 encoding basic option

### DIFF
--- a/src/main/java/io/vertx/codegen/json/annotations/JsonGen.java
+++ b/src/main/java/io/vertx/codegen/json/annotations/JsonGen.java
@@ -50,6 +50,8 @@ public @interface JsonGen {
    * </ul>
    *
    * @return if generated converters are enabled, buffers should default to the configured type.
+   * @deprecated avoid using this attribute which defaults to {@code base64url} which is the only type supported in Vert.x 5
    */
+  @Deprecated
   String base64Type() default "";
 }


### PR DESCRIPTION
Motivation:

Legacy Buffer base64 encoding stemming from Vert.x 3 is deprecated in Vert.x 4.x

Changes:

Deprecate the base64Type member of the @JsonGen annotation.
