### PR TITLE
Remove logger usage to converge to the annotation processor messager

### DIFF
--- a/vertx-codegen-json/pom.xml
+++ b/vertx-codegen-json/pom.xml
@@ -53,6 +53,7 @@
             <execution>
               <id>default-compile</id>
               <configuration>
+                <showWarnings>true</showWarnings>
                 <annotationProcessorPaths>
                   <annotationProcessorPath>
                     <groupId>io.vertx</groupId>

--- a/vertx-codegen-processor/README.md
+++ b/vertx-codegen-processor/README.md
@@ -48,6 +48,7 @@ You can configure the `>io.vertx.codegen.processor.Processor` as any Java annota
         <encoding>${project.build.sourceEncoding}</encoding>
         <!-- Important: there are issues with apt and incremental compilation in the maven-compiler-plugin -->
         <useIncrementalCompilation>false</useIncrementalCompilation>
+        <showWarnings>true</showWarnings>
       </configuration>
       <executions>
         <execution>

--- a/vertx-codegen-processor/pom.xml
+++ b/vertx-codegen-processor/pom.xml
@@ -214,6 +214,7 @@
                 <classpathElement>${project.build.directory}/test-classpath</classpathElement>
                 <classpathElement>${project.basedir}/src/tck/resources</classpathElement>
               </classpathElements>
+              <outputDiagnostics>true</outputDiagnostics>
               <processors>
                 <processor>io.vertx.codegen.processor.Processor</processor>
               </processors>

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/ClassModel.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/ClassModel.java
@@ -34,7 +34,6 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import java.util.*;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -54,7 +53,6 @@ public class ClassModel implements Model {
   public static final String ITERATOR = "java.util.Iterator";
   public static final String FUNCTION = "java.util.function.Function";
   public static final String SUPPLIER = "java.util.function.Supplier";
-  private static final Logger logger = Logger.getLogger(ClassModel.class.getName());
 
   protected final ProcessingEnvironment env;
   protected final AnnotationValueInfoFactory annotationValueInfoFactory;
@@ -697,7 +695,7 @@ public class ClassModel implements Model {
         String msg = "Interface " + modelElt + " does not redeclare the @Fluent return type " +
             " of method " + modelMethod + " declared by " + declaringElt;
         messager.printMessage(Diagnostic.Kind.WARNING, msg, modelElt, fluentAnnotation);
-        logger.warning(msg);
+        env.getMessager().printMessage(Diagnostic.Kind.WARNING, msg);
       } else {
         TypeMirror fluentType = modelMethod.getReturnType();
         if (!typeUtils.isAssignable(fluentType, modelElt.asType())) {

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/CodeGen.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/CodeGen.java
@@ -20,7 +20,6 @@ import javax.lang.model.util.Types;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 /**
@@ -46,7 +45,6 @@ public class CodeGen {
     PROVIDERS = list;
   }
 
-  private static final Logger logger = Logger.getLogger(CodeGen.class.getName());
   final static Map<ProcessingEnvironment, ClassLoader> loaderMap = new WeakHashMap<>();
 
   private final Map<String, Map<String, Map.Entry<TypeElement, Model>>> models = new HashMap<>();

--- a/vertx-codegen-protobuf/pom.xml
+++ b/vertx-codegen-protobuf/pom.xml
@@ -74,6 +74,7 @@
                     <classifier>processor</classifier>
                   </annotationProcessorPath>
                 </annotationProcessorPaths>
+                <showWarnings>true</showWarnings>
                 <compilerArgs>
                   <arg>-Adocgen.source=${asciidoc.dir}</arg>
                   <arg>-Adocgen.output=${project.build.directory}/asciidoc/java</arg>

--- a/vertx-codegen-protobuf/src/main/asciidoc/index.adoc
+++ b/vertx-codegen-protobuf/src/main/asciidoc/index.adoc
@@ -147,6 +147,7 @@ Lombok uses internal compiler API to update Abstract Syntax Tree of the compiler
         <version>${vertx.version}</version>
       </path>
     </annotationProcessorPaths>
+    <showWarnings>true</showWarnings>
   </configuration>
 </plugin>
 ----


### PR DESCRIPTION
This brings more consistent message and error reporting than what JDK logging does, and it does not mess with build tools output.
