### PR TITLE
Permitted type declarations

### DIFF
--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/ClassModel.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/ClassModel.java
@@ -454,8 +454,13 @@ public class ClassModel implements Model {
               if (allowAnyJavaType) {
                 anyJavaTypeMethods.put(elt, meth);
               } else {
-                methodAnnotationsMap.put(meth.getName(), elt.getAnnotationMirrors().stream().map(annotationValueInfoFactory::processAnnotation).collect(Collectors.toList()));
-                methods.put(elt, meth);
+                boolean isAnyJavaType = TypeValidator.isAnyJavaType(meth);
+                if (isAnyJavaType) {
+                  anyJavaTypeMethods.put(elt, meth);
+                } else {
+                  methodAnnotationsMap.put(meth.getName(), elt.getAnnotationMirrors().stream().map(annotationValueInfoFactory::processAnnotation).collect(Collectors.toList()));
+                  methods.put(elt, meth);
+                }
               }
             }
           });

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/ApiTypeInfo.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/ApiTypeInfo.java
@@ -23,7 +23,7 @@ public class ApiTypeInfo extends ClassTypeInfo {
       boolean nullable,
       boolean proxyGen,
       DataObjectInfo dataObject) {
-    super(ClassKind.API, fqcn, module, nullable, params, dataObject);
+    super(ClassKind.API, fqcn, module, nullable, params, false, dataObject);
     this.concrete = concrete;
     this.proxyGen = proxyGen;
     this.handlerArg = handlerArg;

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/ClassTypeInfo.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/ClassTypeInfo.java
@@ -23,7 +23,7 @@ public class ClassTypeInfo extends TypeInfo {
         Float.class, Double.class, Character.class};
     for (Class<?> boxe : boxes) {
       String name = boxe.getName();
-      PRIMITIVES.put(name, new ClassTypeInfo(ClassKind.BOXED_PRIMITIVE, name, null, false, Collections.emptyList(), null));
+      PRIMITIVES.put(name, new ClassTypeInfo(ClassKind.BOXED_PRIMITIVE, name, null, false, Collections.emptyList(), false, null));
     }
   }
 
@@ -35,8 +35,9 @@ public class ClassTypeInfo extends TypeInfo {
   final boolean nullable;
   final List<TypeParamInfo.Class> params;
   final DataObjectInfo dataObject;
+  final boolean permitted;
 
-  public ClassTypeInfo(ClassKind kind, String name, ModuleInfo module, boolean nullable, List<TypeParamInfo.Class> params, DataObjectInfo dataObject) {
+  public ClassTypeInfo(ClassKind kind, String name, ModuleInfo module, boolean nullable, List<TypeParamInfo.Class> params, boolean permitted, DataObjectInfo dataObject) {
     this.kind = kind;
     this.name = name;
     this.simpleName = Helper.getSimpleName(name);
@@ -44,7 +45,12 @@ public class ClassTypeInfo extends TypeInfo {
     this.module = module;
     this.nullable = nullable;
     this.params = params;
+    this.permitted = permitted;
     this.dataObject = dataObject;
+  }
+
+  public boolean isPermitted() {
+    return permitted;
   }
 
   public List<TypeParamInfo.Class> getParams() {

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/EnumTypeInfo.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/EnumTypeInfo.java
@@ -15,7 +15,7 @@ public class EnumTypeInfo extends ClassTypeInfo {
 
   public EnumTypeInfo(String fqcn, boolean gen, List<String> values,
 		  ModuleInfo module, boolean nullable, DataObjectInfo dataObject) {
-    super(ClassKind.ENUM, fqcn, module, nullable, Collections.emptyList(), dataObject);
+    super(ClassKind.ENUM, fqcn, module, nullable, Collections.emptyList(), false, dataObject);
 
     this.gen = gen;
     this.values = values;

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeMirrorFactory.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeMirrorFactory.java
@@ -1,6 +1,7 @@
 package io.vertx.codegen.processor.type;
 
 import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.codegen.processor.*;
@@ -23,8 +24,8 @@ import java.util.Map;
 public class TypeMirrorFactory {
 
   public static final ModuleInfo VERTX_CORE_MOD = new ModuleInfo("io.vertx.core", "vertx", "io.vertx");
-  public static final ClassTypeInfo JSON_OBJECT = new ClassTypeInfo(ClassKind.JSON_OBJECT, "io.vertx.core.json.JsonObject", VERTX_CORE_MOD, false, Collections.emptyList(), null);
-  public static final ClassTypeInfo STRING = new ClassTypeInfo(ClassKind.STRING, "java.lang.String", null, false, Collections.emptyList(), null);
+  public static final ClassTypeInfo JSON_OBJECT = new ClassTypeInfo(ClassKind.JSON_OBJECT, "io.vertx.core.json.JsonObject", VERTX_CORE_MOD, false, Collections.emptyList(), false, null);
+  public static final ClassTypeInfo STRING = new ClassTypeInfo(ClassKind.STRING, "java.lang.String", null, false, Collections.emptyList(), false, null);
 
   final Elements elementUtils;
   final Types typeUtils;
@@ -133,7 +134,7 @@ public class TypeMirrorFactory {
         if (kind == ClassKind.BOXED_PRIMITIVE) {
           raw = ClassTypeInfo.PRIMITIVES.get(fqcn);
           if (nullable) {
-            raw = new ClassTypeInfo(raw.kind, raw.name, raw.module, true, raw.params, null);
+            raw = new ClassTypeInfo(raw.kind, raw.name, raw.module, true, raw.params, false, null);
           }
         } else {
           MapperInfo serializer = serializers.get(fqcn);
@@ -150,6 +151,13 @@ public class TypeMirrorFactory {
           DataObjectInfo dataObject = null;
           if (annotated || serializer != null || deserializer != null) {
             dataObject = new DataObjectInfo(annotated, serializer, deserializer);
+          }
+
+          boolean permitted;
+          if (elt.getAnnotation(GenIgnore.class) != null) {
+            permitted = true;
+          } else {
+            permitted = false;
           }
 
           List<TypeParamInfo.Class> typeParams = createTypeParams(type);
@@ -173,7 +181,7 @@ public class TypeMirrorFactory {
             }
             raw = new ApiTypeInfo(fqcn, genAnn.concrete(), typeParams, handlerArg, module, nullable, proxyGen, dataObject);
           } else {
-            raw = new ClassTypeInfo(kind, fqcn, module, nullable, typeParams, dataObject);
+            raw = new ClassTypeInfo(kind, fqcn, module, nullable, typeParams, permitted, dataObject);
           }
         }
         return raw;

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeReflectionFactory.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeReflectionFactory.java
@@ -1,5 +1,6 @@
 package io.vertx.codegen.processor.type;
 
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.processor.Helper;
 import io.vertx.codegen.processor.MapperKind;
 import io.vertx.codegen.processor.ModuleInfo;
@@ -81,14 +82,21 @@ public class TypeReflectionFactory {
             return new ApiTypeInfo(fqcn, true, typeParams, handlerArg != null ? create(handlerArg) : null, module, false, false, null);
           } else {
             DataObjectInfo dataObject;
+            boolean permitted;
             if (classType.getDeclaredAnnotation(DataObject.class) != null) {
               MapperInfo serializer = getDataObjectSerializer(classType);
               MapperInfo deserializer = getDataObjectDeserializer(classType);
               dataObject = new DataObjectInfo(true, serializer, deserializer);
+              permitted = false;
             } else {
               dataObject = null;
+              if (classType.getDeclaredAnnotation(GenIgnore.class) != null) {
+                permitted = true;
+              } else {
+                permitted = false;
+              }
             }
-            return new ClassTypeInfo(kind, fqcn, module, false, typeParams, dataObject);
+            return new ClassTypeInfo(kind, fqcn, module, false, typeParams, permitted, dataObject);
           }
         }
       }

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeVariableInfo.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeVariableInfo.java
@@ -48,7 +48,7 @@ public class TypeVariableInfo extends TypeInfo {
 
   @Override
   public TypeInfo getErased() {
-    return new ClassTypeInfo(ClassKind.OBJECT, Object.class.getName(), null, false, Collections.emptyList(), null);
+    return new ClassTypeInfo(ClassKind.OBJECT, Object.class.getName(), null, false, Collections.emptyList(), false, null);
   }
 
   @Override

--- a/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/ClassTest.java
+++ b/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/ClassTest.java
@@ -25,10 +25,7 @@ import io.vertx.test.codegen.testapi.handler.InterfaceExtendingHandlerStringSubt
 import io.vertx.test.codegen.testapi.handler.InterfaceExtendingHandlerVertxGenSubtype;
 import io.vertx.test.codegen.testapi.impl.InterfaceInImplPackage;
 import io.vertx.test.codegen.testapi.impl.sub.InterfaceInImplParentPackage;
-import io.vertx.test.codegen.testapi.javatypes.MethodWithInvalidJavaTypeParam;
-import io.vertx.test.codegen.testapi.javatypes.MethodWithInvalidJavaTypeReturn;
-import io.vertx.test.codegen.testapi.javatypes.MethodWithValidJavaTypeParams;
-import io.vertx.test.codegen.testapi.javatypes.MethodWithValidJavaTypeReturn;
+import io.vertx.test.codegen.testapi.javatypes.*;
 import io.vertx.test.codegen.testapi.jsonmapper.MyPojo;
 import io.vertx.test.codegen.testapi.jsonmapper.WithMyPojo;
 import io.vertx.test.codegen.testapi.kotlin.InterfaceWithCompanionObject;
@@ -345,7 +342,7 @@ public class ClassTest extends ClassTestBase {
     assertEquals(1, model.getMethods().size());
     MethodInfo mi = model.getMethods().get(0);
     assertEquals("foo", mi.getName());
-    assertEquals(new ParameterizedTypeInfo(new ClassTypeInfo(ClassKind.API, GenericInterface.class.getName(), null, false, Collections.emptyList(), null), false, Arrays.asList(TypeReflectionFactory.create(Void.class))), mi.getParams().get(0).getType());
+    assertEquals(new ParameterizedTypeInfo(new ClassTypeInfo(ClassKind.API, GenericInterface.class.getName(), null, false, Collections.emptyList(), false, null), false, Arrays.asList(TypeReflectionFactory.create(Void.class))), mi.getParams().get(0).getType());
     ParameterizedTypeInfo genericType = (ParameterizedTypeInfo) mi.getParams().get(0).getType();
     ClassTypeInfo voidType = (ClassTypeInfo) genericType.getArgs().get(0);
     assertEquals(ClassKind.VOID, voidType.getKind());
@@ -790,10 +787,10 @@ public class ClassTest extends ClassTestBase {
   @Test
   public void testValidJavaTypeParams() throws Exception {
     ClassModel model = new GeneratorHelper().generateClass(MethodWithValidJavaTypeParams.class);
-    assertEquals(6, model.getAnyJavaTypeMethods().size());
+    assertEquals(14, model.getAnyJavaTypeMethods().size());
 
     MethodInfo method = model.getAnyJavaTypeMethods().get(0);
-    checkMethod(method, "methodWithParams", 4, "void", MethodKind.OTHER);
+    checkMethod(method, "methodWithParams0", 4, "void", MethodKind.OTHER);
     List<ParamInfo> params = method.getParams();
     checkParam(params.get(0), "socket", new TypeLiteral<Socket>(){});
     checkParam(params.get(1), "listSocket", new TypeLiteral<List<Socket>>(){});
@@ -802,7 +799,7 @@ public class ClassTest extends ClassTestBase {
     assertTrue(method.isContainingAnyJavaType());
 
     method = model.getAnyJavaTypeMethods().get(1);
-    checkMethod(method, "methodWithHandlerParams", 4, "void", MethodKind.HANDLER);
+    checkMethod(method, "methodWithHandlerParams0", 4, "void", MethodKind.HANDLER);
     params = method.getParams();
     checkParam(params.get(0), "socketHandler", new TypeLiteral<Handler<Socket>>(){});
     checkParam(params.get(1), "listSocketHandler", new TypeLiteral<Handler<List<Socket>>>(){});
@@ -811,7 +808,7 @@ public class ClassTest extends ClassTestBase {
     assertTrue(method.isContainingAnyJavaType());
 
     method = model.getAnyJavaTypeMethods().get(2);
-    checkMethod(method, "methodWithFunctionParams", 4, "void", MethodKind.OTHER);
+    checkMethod(method, "methodWithFunctionParams0", 4, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "socketFunction", new TypeLiteral<Function<Socket, Socket>>(){});
     checkParam(params.get(1), "listSocketFunction", new TypeLiteral<Function<List<Socket>, List<Socket>>>(){});
@@ -820,7 +817,7 @@ public class ClassTest extends ClassTestBase {
     assertTrue(method.isContainingAnyJavaType());
 
     method = model.getAnyJavaTypeMethods().get(3);
-    checkMethod(method, "methodWithSupplierParams", 4, "void", MethodKind.OTHER);
+    checkMethod(method, "methodWithSupplierParams0", 4, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "socketSupplier", new TypeLiteral<Supplier<Socket>>(){});
     checkParam(params.get(1), "listSocketSupplier", new TypeLiteral<Supplier<List<Socket>>>(){});
@@ -829,13 +826,85 @@ public class ClassTest extends ClassTestBase {
     assertTrue(method.isContainingAnyJavaType());
 
     method = model.getAnyJavaTypeMethods().get(4);
+    checkMethod(method, "methodWithParams1", 4, "void", MethodKind.OTHER);
+    params = method.getParams();
+    checkParam(params.get(0), "socket", new TypeLiteral<PermittedType>(){});
+    checkParam(params.get(1), "listSocket", new TypeLiteral<List<PermittedType>>(){});
+    checkParam(params.get(2), "setSocket", new TypeLiteral<Set<PermittedType>>(){});
+    checkParam(params.get(3), "mapSocket", new TypeLiteral<Map<String, PermittedType>>(){});
+    assertTrue(method.isContainingAnyJavaType());
+
+    method = model.getAnyJavaTypeMethods().get(5);
+    checkMethod(method, "methodWithHandlerParams1", 4, "void", MethodKind.HANDLER);
+    params = method.getParams();
+    checkParam(params.get(0), "socketHandler", new TypeLiteral<Handler<PermittedType>>(){});
+    checkParam(params.get(1), "listSocketHandler", new TypeLiteral<Handler<List<PermittedType>>>(){});
+    checkParam(params.get(2), "setSocketHandler", new TypeLiteral<Handler<Set<PermittedType>>>(){});
+    checkParam(params.get(3), "mapSocketHandler", new TypeLiteral<Handler<Map<String, PermittedType>>>(){});
+    assertTrue(method.isContainingAnyJavaType());
+
+    method = model.getAnyJavaTypeMethods().get(6);
+    checkMethod(method, "methodWithFunctionParams1", 4, "void", MethodKind.OTHER);
+    params = method.getParams();
+    checkParam(params.get(0), "socketFunction", new TypeLiteral<Function<PermittedType, PermittedType>>(){});
+    checkParam(params.get(1), "listSocketFunction", new TypeLiteral<Function<List<PermittedType>, List<PermittedType>>>(){});
+    checkParam(params.get(2), "setSocketFunction", new TypeLiteral<Function<Set<PermittedType>, Set<PermittedType>>>(){});
+    checkParam(params.get(3), "mapSocketFunction", new TypeLiteral<Function<Map<String, PermittedType>, Map<String, PermittedType>>>(){});
+    assertTrue(method.isContainingAnyJavaType());
+
+    method = model.getAnyJavaTypeMethods().get(7);
+    checkMethod(method, "methodWithSupplierParams1", 4, "void", MethodKind.OTHER);
+    params = method.getParams();
+    checkParam(params.get(0), "socketSupplier", new TypeLiteral<Supplier<PermittedType>>(){});
+    checkParam(params.get(1), "listSocketSupplier", new TypeLiteral<Supplier<List<PermittedType>>>(){});
+    checkParam(params.get(2), "setSocketSupplier", new TypeLiteral<Supplier<Set<PermittedType>>>(){});
+    checkParam(params.get(3), "mapSocketSupplier", new TypeLiteral<Supplier<Map<String, PermittedType>>>(){});
+    assertTrue(method.isContainingAnyJavaType());
+
+    method = model.getAnyJavaTypeMethods().get(8);
+    checkMethod(method, "methodWithParams2", 4, "void", MethodKind.OTHER);
+    params = method.getParams();
+    checkParam(params.get(0), "socket", new TypeLiteral<PermittedType>(){});
+    checkParam(params.get(1), "listSocket", new TypeLiteral<List<PermittedType>>(){});
+    checkParam(params.get(2), "setSocket", new TypeLiteral<Set<PermittedType>>(){});
+    checkParam(params.get(3), "mapSocket", new TypeLiteral<Map<String, PermittedType>>(){});
+    assertTrue(method.isContainingAnyJavaType());
+
+    method = model.getAnyJavaTypeMethods().get(9);
+    checkMethod(method, "methodWithHandlerParams2", 4, "void", MethodKind.HANDLER);
+    params = method.getParams();
+    checkParam(params.get(0), "socketHandler", new TypeLiteral<Handler<ParameterizedPermittedType<String>>>(){});
+    checkParam(params.get(1), "listSocketHandler", new TypeLiteral<Handler<List<ParameterizedPermittedType<String>>>>(){});
+    checkParam(params.get(2), "setSocketHandler", new TypeLiteral<Handler<Set<ParameterizedPermittedType<String>>>>(){});
+    checkParam(params.get(3), "mapSocketHandler", new TypeLiteral<Handler<Map<String, ParameterizedPermittedType<String>>>>(){});
+    assertTrue(method.isContainingAnyJavaType());
+
+    method = model.getAnyJavaTypeMethods().get(10);
+    checkMethod(method, "methodWithFunctionParams2", 4, "void", MethodKind.OTHER);
+    params = method.getParams();
+    checkParam(params.get(0), "socketFunction", new TypeLiteral<Function<ParameterizedPermittedType<String>, ParameterizedPermittedType<String>>>(){});
+    checkParam(params.get(1), "listSocketFunction", new TypeLiteral<Function<List<ParameterizedPermittedType<String>>, List<ParameterizedPermittedType<String>>>>(){});
+    checkParam(params.get(2), "setSocketFunction", new TypeLiteral<Function<Set<ParameterizedPermittedType<String>>, Set<ParameterizedPermittedType<String>>>>(){});
+    checkParam(params.get(3), "mapSocketFunction", new TypeLiteral<Function<Map<String, ParameterizedPermittedType<String>>, Map<String, ParameterizedPermittedType<String>>>>(){});
+    assertTrue(method.isContainingAnyJavaType());
+
+    method = model.getAnyJavaTypeMethods().get(11);
+    checkMethod(method, "methodWithSupplierParams2", 4, "void", MethodKind.OTHER);
+    params = method.getParams();
+    checkParam(params.get(0), "socketSupplier", new TypeLiteral<Supplier<ParameterizedPermittedType<String>>>(){});
+    checkParam(params.get(1), "listSocketSupplier", new TypeLiteral<Supplier<List<ParameterizedPermittedType<String>>>>(){});
+    checkParam(params.get(2), "setSocketSupplier", new TypeLiteral<Supplier<Set<ParameterizedPermittedType<String>>>>(){});
+    checkParam(params.get(3), "mapSocketSupplier", new TypeLiteral<Supplier<Map<String, ParameterizedPermittedType<String>>>>(){});
+    assertTrue(method.isContainingAnyJavaType());
+
+    method = model.getAnyJavaTypeMethods().get(12);
     checkMethod(method, "methodWithArrayParams", 2, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "byteArray", new TypeLiteral<byte[]>(){});
     checkParam(params.get(1), "booleanArray", new TypeLiteral<boolean[]>(){});
     assertTrue(method.isContainingAnyJavaType());
 
-    method = model.getAnyJavaTypeMethods().get(5);
+    method = model.getAnyJavaTypeMethods().get(13);
     checkMethod(method, "methodWithParameterizedParams", 1, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "iterableString", new TypeLiteral<Iterable<String>>(){});

--- a/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/testapi/javatypes/MethodWithValidJavaTypeParams.java
+++ b/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/testapi/javatypes/MethodWithValidJavaTypeParams.java
@@ -36,28 +36,68 @@ import java.util.function.Supplier;
 public interface MethodWithValidJavaTypeParams {
 
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  void methodWithParams(Socket socket,
+  void methodWithParams0(Socket socket,
                         List<Socket> listSocket,
                         Set<Socket> setSocket,
                         Map<String, Socket> mapSocket);
 
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  void methodWithHandlerParams(Handler<Socket> socketHandler,
+  void methodWithHandlerParams0(Handler<Socket> socketHandler,
                                Handler<List<Socket>> listSocketHandler,
                                Handler<Set<Socket>> setSocketHandler,
                                Handler<Map<String, Socket>> mapSocketHandler);
 
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  void methodWithFunctionParams(Function<Socket, Socket> socketFunction,
+  void methodWithFunctionParams0(Function<Socket, Socket> socketFunction,
                                 Function<List<Socket>, List<Socket>> listSocketFunction,
                                 Function<Set<Socket>, Set<Socket>> setSocketFunction,
                                 Function<Map<String, Socket>, Map<String, Socket>> mapSocketFunction);
 
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  void methodWithSupplierParams(Supplier<Socket> socketSupplier,
+  void methodWithSupplierParams0(Supplier<Socket> socketSupplier,
                                 Supplier<List<Socket>> listSocketSupplier,
                                 Supplier<Set<Socket>> setSocketSupplier,
                                 Supplier<Map<String, Socket>> mapSocketSupplier);
+
+  void methodWithParams1(PermittedType socket,
+                        List<PermittedType> listSocket,
+                        Set<PermittedType> setSocket,
+                        Map<String, PermittedType> mapSocket);
+
+  void methodWithHandlerParams1(Handler<PermittedType> socketHandler,
+                               Handler<List<PermittedType>> listSocketHandler,
+                               Handler<Set<PermittedType>> setSocketHandler,
+                               Handler<Map<String, PermittedType>> mapSocketHandler);
+
+  void methodWithFunctionParams1(Function<PermittedType, PermittedType> socketFunction,
+                                Function<List<PermittedType>, List<PermittedType>> listSocketFunction,
+                                Function<Set<PermittedType>, Set<PermittedType>> setSocketFunction,
+                                Function<Map<String, PermittedType>, Map<String, PermittedType>> mapSocketFunction);
+
+  void methodWithSupplierParams1(Supplier<PermittedType> socketSupplier,
+                                Supplier<List<PermittedType>> listSocketSupplier,
+                                Supplier<Set<PermittedType>> setSocketSupplier,
+                                Supplier<Map<String, PermittedType>> mapSocketSupplier);
+
+  void methodWithParams2(PermittedType socket,
+                         List<PermittedType> listSocket,
+                         Set<PermittedType> setSocket,
+                         Map<String, PermittedType> mapSocket);
+
+  void methodWithHandlerParams2(Handler<ParameterizedPermittedType<String>> socketHandler,
+                                Handler<List<ParameterizedPermittedType<String>>> listSocketHandler,
+                                Handler<Set<ParameterizedPermittedType<String>>> setSocketHandler,
+                                Handler<Map<String, ParameterizedPermittedType<String>>> mapSocketHandler);
+
+  void methodWithFunctionParams2(Function<ParameterizedPermittedType<String>, ParameterizedPermittedType<String>> socketFunction,
+                                 Function<List<ParameterizedPermittedType<String>>, List<ParameterizedPermittedType<String>>> listSocketFunction,
+                                 Function<Set<ParameterizedPermittedType<String>>, Set<ParameterizedPermittedType<String>>> setSocketFunction,
+                                 Function<Map<String, ParameterizedPermittedType<String>>, Map<String, ParameterizedPermittedType<String>>> mapSocketFunction);
+
+  void methodWithSupplierParams2(Supplier<ParameterizedPermittedType<String>> socketSupplier,
+                                 Supplier<List<ParameterizedPermittedType<String>>> listSocketSupplier,
+                                 Supplier<Set<ParameterizedPermittedType<String>>> setSocketSupplier,
+                                 Supplier<Map<String, ParameterizedPermittedType<String>>> mapSocketSupplier);
 
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   void methodWithArrayParams(byte[] byteArray,

--- a/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/testapi/javatypes/ParameterizedPermittedType.java
+++ b/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/testapi/javatypes/ParameterizedPermittedType.java
@@ -1,0 +1,7 @@
+package io.vertx.test.codegen.testapi.javatypes;
+
+import io.vertx.codegen.annotations.GenIgnore;
+
+@GenIgnore(GenIgnore.PERMITTED_TYPE)
+public interface ParameterizedPermittedType<T> {
+}

--- a/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/testapi/javatypes/PermittedType.java
+++ b/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/testapi/javatypes/PermittedType.java
@@ -1,0 +1,7 @@
+package io.vertx.test.codegen.testapi.javatypes;
+
+import io.vertx.codegen.annotations.GenIgnore;
+
+@GenIgnore(GenIgnore.PERMITTED_TYPE)
+public interface PermittedType {
+}


### PR DESCRIPTION
Allow an interface to be annoated with `@GenIgnore(GenIgnore.PERMITTED_TYPE)` to automatically promote a method that declares this type among parameters or return types.
