### PR TITLE
Support wildcard declarations for permitted types

### DIFF
--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeMirrorFactory.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeMirrorFactory.java
@@ -80,6 +80,8 @@ public class TypeMirrorFactory {
         return create(use, (TypeVariable) type);
       case ARRAY:
         return create(use, (ArrayType) type);
+      case WILDCARD:
+        return create(use, (WildcardType) type);
       default:
         throw new IllegalArgumentException("Illegal type " + type + " of kind " + type.getKind());
     }
@@ -198,6 +200,12 @@ public class TypeMirrorFactory {
   public ArrayTypeInfo create(TypeUse use, ArrayType type) {
     TypeMirror componentType = type.getComponentType();
     return new ArrayTypeInfo(create(componentType), use != null && use.isNullable());
+  }
+
+  public WildcardTypeInfo create(TypeUse use, WildcardType type) {
+    TypeInfo extendsBound = type.getExtendsBound() != null ? create(use, type.getExtendsBound()) : null;
+    TypeInfo superBound = type.getSuperBound() != null ? create(use, type.getSuperBound()) : null;
+    return new WildcardTypeInfo(extendsBound, superBound);
   }
 
   private List<TypeParamInfo.Class> createTypeParams(DeclaredType type) {

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeReflectionFactory.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/TypeReflectionFactory.java
@@ -112,6 +112,15 @@ public class TypeReflectionFactory {
       java.lang.reflect.TypeVariable typeVar = (java.lang.reflect.TypeVariable) type;
       TypeParamInfo param = TypeParamInfo.create(typeVar);
       return new TypeVariableInfo(param, false, ((java.lang.reflect.TypeVariable) type).getName());
+    } else if (type instanceof  WildcardType) {
+      WildcardType wildcardType = (WildcardType) type;
+      if (wildcardType.getUpperBounds().length > 0) {
+        return new WildcardTypeInfo(create(wildcardType.getUpperBounds()[0]), null);
+      } else if (wildcardType.getLowerBounds().length > 0) {
+        return new WildcardTypeInfo(null, create(wildcardType.getLowerBounds()[0]));
+      } else {
+        return new WildcardTypeInfo(null, null);
+      }
     } else {
       throw new IllegalArgumentException("Unsupported type " + type);
     }

--- a/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/WildcardTypeInfo.java
+++ b/vertx-codegen-processor/src/main/java/io/vertx/codegen/processor/type/WildcardTypeInfo.java
@@ -1,0 +1,51 @@
+package io.vertx.codegen.processor.type;
+
+import javax.lang.model.type.WildcardType;
+import java.util.Objects;
+
+public class WildcardTypeInfo extends TypeInfo {
+
+  private final TypeInfo extendsBound;
+  private final TypeInfo superBound;
+
+  public WildcardTypeInfo(TypeInfo extendsBound, TypeInfo superBound) {
+    this.extendsBound = extendsBound;
+    this.superBound = superBound;
+  }
+
+  public TypeInfo getExtendsBound() {
+    return extendsBound;
+  }
+
+  public TypeInfo getSuperBound() {
+    return superBound;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj instanceof WildcardTypeInfo) {
+      WildcardTypeInfo that = (WildcardTypeInfo) obj;
+      return Objects.equals(extendsBound, that.extendsBound) && Objects.equals(superBound, that.superBound);
+    }
+    return false;
+  }
+
+  @Override
+  public ClassKind getKind() {
+    return ClassKind.OTHER;
+  }
+
+  @Override
+  String format(boolean qualified) {
+    if (extendsBound != null) {
+      return "? extends " + extendsBound.format(qualified);
+    } else if (superBound != null) {
+      return "? super " + superBound.format(qualified);
+    } else {
+      return "?";
+    }
+  }
+}

--- a/vertx-codegen-processor/src/tck/java/io/vertx/codegen/testmodel/AnyJavaTypeTCK.java
+++ b/vertx-codegen-processor/src/tck/java/io/vertx/codegen/testmodel/AnyJavaTypeTCK.java
@@ -33,4 +33,12 @@ public interface AnyJavaTypeTCK {
   @GenIgnore(GenIgnore.PERMITTED_TYPE) Future<List<Socket>> methodWithHandlerAsyncResultListOfJavaTypeParam();
   @GenIgnore(GenIgnore.PERMITTED_TYPE) Future<Set<Socket>> methodWithHandlerAsyncResultSetOfJavaTypeParam();
   @GenIgnore(GenIgnore.PERMITTED_TYPE) Future<Map<String, Socket>> methodWithHandlerAsyncResultMapOfJavaTypeParam();
+
+  @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithWildcardParam(List<?> socketList);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithExtendsWildcardParam(List<? extends Socket> socketSet);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE) void methodWithSuperWildcardParam(List<? super Socket> socketMap);
+
+  @GenIgnore(GenIgnore.PERMITTED_TYPE) List<?> methodWithWildcardReturn();
+  @GenIgnore(GenIgnore.PERMITTED_TYPE) List<? extends Socket> methodWithExtendsWildcardReturn();
+  @GenIgnore(GenIgnore.PERMITTED_TYPE) List<? super Socket> methodWithSuperWildcardReturn();
 }

--- a/vertx-codegen-processor/src/tck/java/io/vertx/codegen/testmodel/AnyJavaTypeTCKImpl.java
+++ b/vertx-codegen-processor/src/tck/java/io/vertx/codegen/testmodel/AnyJavaTypeTCKImpl.java
@@ -132,4 +132,31 @@ public class AnyJavaTypeTCKImpl implements AnyJavaTypeTCK {
     sockets.put("1", socket);
     return Future.succeededFuture(sockets);
   }
+
+  @Override
+  public void methodWithWildcardParam(List<?> socketList) {
+  }
+
+  @Override
+  public void methodWithExtendsWildcardParam(List<? extends Socket> socketSet) {
+  }
+
+  @Override
+  public void methodWithSuperWildcardParam(List<? super Socket> socketMap) {
+  }
+
+  @Override
+  public List<?> methodWithWildcardReturn() {
+    return List.of();
+  }
+
+  @Override
+  public List<? extends Socket> methodWithExtendsWildcardReturn() {
+    return List.of();
+  }
+
+  @Override
+  public List<? super Socket> methodWithSuperWildcardReturn() {
+    return List.of();
+  }
 }

--- a/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/ClassTest.java
+++ b/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/ClassTest.java
@@ -787,7 +787,7 @@ public class ClassTest extends ClassTestBase {
   @Test
   public void testValidJavaTypeParams() throws Exception {
     ClassModel model = new GeneratorHelper().generateClass(MethodWithValidJavaTypeParams.class);
-    assertEquals(14, model.getAnyJavaTypeMethods().size());
+    assertEquals(15, model.getAnyJavaTypeMethods().size());
 
     MethodInfo method = model.getAnyJavaTypeMethods().get(0);
     checkMethod(method, "methodWithParams0", 4, "void", MethodKind.OTHER);
@@ -826,6 +826,14 @@ public class ClassTest extends ClassTestBase {
     assertTrue(method.isContainingAnyJavaType());
 
     method = model.getAnyJavaTypeMethods().get(4);
+    checkMethod(method, "methodWithBilto0", 3, "void", MethodKind.OTHER);
+    params = method.getParams();
+    checkParam(params.get(0), "listSocket", new TypeLiteral<List<? extends Socket>>(){});
+    checkParam(params.get(1), "setSocket", new TypeLiteral<Set<? extends Socket>>(){});
+    checkParam(params.get(2), "mapSocket", new TypeLiteral<Map<? extends String, ? extends Socket>>(){});
+    assertTrue(method.isContainingAnyJavaType());
+
+    method = model.getAnyJavaTypeMethods().get(5);
     checkMethod(method, "methodWithParams1", 4, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "socket", new TypeLiteral<PermittedType>(){});
@@ -834,7 +842,7 @@ public class ClassTest extends ClassTestBase {
     checkParam(params.get(3), "mapSocket", new TypeLiteral<Map<String, PermittedType>>(){});
     assertTrue(method.isContainingAnyJavaType());
 
-    method = model.getAnyJavaTypeMethods().get(5);
+    method = model.getAnyJavaTypeMethods().get(6);
     checkMethod(method, "methodWithHandlerParams1", 4, "void", MethodKind.HANDLER);
     params = method.getParams();
     checkParam(params.get(0), "socketHandler", new TypeLiteral<Handler<PermittedType>>(){});
@@ -843,7 +851,7 @@ public class ClassTest extends ClassTestBase {
     checkParam(params.get(3), "mapSocketHandler", new TypeLiteral<Handler<Map<String, PermittedType>>>(){});
     assertTrue(method.isContainingAnyJavaType());
 
-    method = model.getAnyJavaTypeMethods().get(6);
+    method = model.getAnyJavaTypeMethods().get(7);
     checkMethod(method, "methodWithFunctionParams1", 4, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "socketFunction", new TypeLiteral<Function<PermittedType, PermittedType>>(){});
@@ -852,7 +860,7 @@ public class ClassTest extends ClassTestBase {
     checkParam(params.get(3), "mapSocketFunction", new TypeLiteral<Function<Map<String, PermittedType>, Map<String, PermittedType>>>(){});
     assertTrue(method.isContainingAnyJavaType());
 
-    method = model.getAnyJavaTypeMethods().get(7);
+    method = model.getAnyJavaTypeMethods().get(8);
     checkMethod(method, "methodWithSupplierParams1", 4, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "socketSupplier", new TypeLiteral<Supplier<PermittedType>>(){});
@@ -861,7 +869,7 @@ public class ClassTest extends ClassTestBase {
     checkParam(params.get(3), "mapSocketSupplier", new TypeLiteral<Supplier<Map<String, PermittedType>>>(){});
     assertTrue(method.isContainingAnyJavaType());
 
-    method = model.getAnyJavaTypeMethods().get(8);
+    method = model.getAnyJavaTypeMethods().get(9);
     checkMethod(method, "methodWithParams2", 4, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "socket", new TypeLiteral<PermittedType>(){});
@@ -870,7 +878,7 @@ public class ClassTest extends ClassTestBase {
     checkParam(params.get(3), "mapSocket", new TypeLiteral<Map<String, PermittedType>>(){});
     assertTrue(method.isContainingAnyJavaType());
 
-    method = model.getAnyJavaTypeMethods().get(9);
+    method = model.getAnyJavaTypeMethods().get(10);
     checkMethod(method, "methodWithHandlerParams2", 4, "void", MethodKind.HANDLER);
     params = method.getParams();
     checkParam(params.get(0), "socketHandler", new TypeLiteral<Handler<ParameterizedPermittedType<String>>>(){});
@@ -879,7 +887,7 @@ public class ClassTest extends ClassTestBase {
     checkParam(params.get(3), "mapSocketHandler", new TypeLiteral<Handler<Map<String, ParameterizedPermittedType<String>>>>(){});
     assertTrue(method.isContainingAnyJavaType());
 
-    method = model.getAnyJavaTypeMethods().get(10);
+    method = model.getAnyJavaTypeMethods().get(11);
     checkMethod(method, "methodWithFunctionParams2", 4, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "socketFunction", new TypeLiteral<Function<ParameterizedPermittedType<String>, ParameterizedPermittedType<String>>>(){});
@@ -888,7 +896,7 @@ public class ClassTest extends ClassTestBase {
     checkParam(params.get(3), "mapSocketFunction", new TypeLiteral<Function<Map<String, ParameterizedPermittedType<String>>, Map<String, ParameterizedPermittedType<String>>>>(){});
     assertTrue(method.isContainingAnyJavaType());
 
-    method = model.getAnyJavaTypeMethods().get(11);
+    method = model.getAnyJavaTypeMethods().get(12);
     checkMethod(method, "methodWithSupplierParams2", 4, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "socketSupplier", new TypeLiteral<Supplier<ParameterizedPermittedType<String>>>(){});
@@ -897,14 +905,14 @@ public class ClassTest extends ClassTestBase {
     checkParam(params.get(3), "mapSocketSupplier", new TypeLiteral<Supplier<Map<String, ParameterizedPermittedType<String>>>>(){});
     assertTrue(method.isContainingAnyJavaType());
 
-    method = model.getAnyJavaTypeMethods().get(12);
+    method = model.getAnyJavaTypeMethods().get(13);
     checkMethod(method, "methodWithArrayParams", 2, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "byteArray", new TypeLiteral<byte[]>(){});
     checkParam(params.get(1), "booleanArray", new TypeLiteral<boolean[]>(){});
     assertTrue(method.isContainingAnyJavaType());
 
-    method = model.getAnyJavaTypeMethods().get(13);
+    method = model.getAnyJavaTypeMethods().get(14);
     checkMethod(method, "methodWithParameterizedParams", 1, "void", MethodKind.OTHER);
     params = method.getParams();
     checkParam(params.get(0), "iterableString", new TypeLiteral<Iterable<String>>(){});

--- a/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/testapi/javatypes/MethodWithValidJavaTypeParams.java
+++ b/vertx-codegen-processor/src/test/java/io/vertx/test/codegen/testapi/javatypes/MethodWithValidJavaTypeParams.java
@@ -59,6 +59,11 @@ public interface MethodWithValidJavaTypeParams {
                                 Supplier<Set<Socket>> setSocketSupplier,
                                 Supplier<Map<String, Socket>> mapSocketSupplier);
 
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  void methodWithBilto0(List<? extends Socket> listSocket,
+                        Set<? extends Socket> setSocket,
+                        Map<? extends String, ? extends Socket> mapSocket);
+
   void methodWithParams1(PermittedType socket,
                         List<PermittedType> listSocket,
                         Set<PermittedType> setSocket,


### PR DESCRIPTION
Motivation:
    
API sometimes needs to use wildcard declarations processed by RxJava like generators.
    
Changes:
    
- simplify the any java type implementation that was more complicated than it had to be
- introduce WildcardTypeInfo created when a wildcard declaration is processed

Result:

Fixes https://github.com/eclipse-vertx/vertx-codegen/issues/63